### PR TITLE
Implemented IO based on h5py and h5md spec

### DIFF
--- a/doc/sphinx/source/modules.rst
+++ b/doc/sphinx/source/modules.rst
@@ -2,6 +2,8 @@ pressomancy
 ===========
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 2
 
    pressomancy
+   pressomancy.object_classes
+   pressomancy.analysis

--- a/doc/sphinx/source/pressomancy.analysis.rst
+++ b/doc/sphinx/source/pressomancy.analysis.rst
@@ -1,0 +1,21 @@
+pressomancy.analysis package
+===================================
+
+Submodules
+----------
+
+pressomancy.analysis.data\_analysis module
+-------------------------------------------------
+
+.. automodule:: pressomancy.analysis.data_analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: pressomancy.analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/source/pressomancy.rst
+++ b/doc/sphinx/source/pressomancy.rst
@@ -33,6 +33,14 @@ pressomancy.simulation module
    :undoc-members:
    :show-inheritance:
 
+pressomancy.analysis module
+---------------------------
+
+.. automodule:: pressomancy.analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/doc/sphinx/source/pressomancy.rst
+++ b/doc/sphinx/source/pressomancy.rst
@@ -9,6 +9,11 @@ Subpackages
 
    pressomancy.object_classes
 
+.. toctree::
+   :maxdepth: 4
+
+   pressomancy.analysis
+
 Submodules
 ----------
 

--- a/pressomancy/analysis/__init__.py
+++ b/pressomancy/analysis/__init__.py
@@ -1,0 +1,1 @@
+from pressomancy.analysis.data_analysis import H5DataSelector

--- a/pressomancy/analysis/data_analysis.py
+++ b/pressomancy/analysis/data_analysis.py
@@ -1,0 +1,116 @@
+class H5DataSelector:
+    """
+    A simplified interface that wraps an HDF5 file with simulation data.
+    Particle properties are stored under:
+       particles/{particle_group}/{prop}/value
+    where each dataset has shape (timesteps, particles, dim).
+    
+    This class holds slice information for timesteps (axis 0) and particles (axis 1)
+    and supports chaining via its accessor properties.
+    """
+    def __init__(self, h5_file, particle_group, ts_slice=None, pt_slice=None):
+        self.h5_file = h5_file
+        self.particle_group = particle_group  # e.g., "Filament"
+        # Default slices: all timesteps and all particles.
+        self.ts_slice = ts_slice if ts_slice is not None else slice(None)
+        self.pt_slice = pt_slice if pt_slice is not None else slice(None)
+
+    def __getitem__(self, key):
+        """
+        Allow slicing using standard indexing syntax.
+        If key is a tuple, we assume (ts_slice, pt_slice).
+        Otherwise, the key applies to the timestep axis.
+        """
+        if isinstance(key, tuple):
+            ts_key, pt_key = key
+        else:
+            ts_key, pt_key = key, self.pt_slice
+        return H5DataSelector(self.h5_file, self.particle_group, ts_slice=ts_key, pt_slice=pt_key)
+
+    @property
+    def timestep(self):
+        """
+        Accessor to slice the timestep axis.
+        Usage: data.timestep[-5:] returns a new H5DataSelector with ts_slice updated.
+        """
+        return TimestepAccessor(self)
+
+    @property
+    def particles(self):
+        """
+        Accessor to slice the particle axis.
+        Usage: data.particles[0:100] returns a new H5DataSelector with pt_slice updated.
+        """
+        return ParticleAccessor(self)
+
+    def get_property(self, prop):
+        """
+        Retrieve data for a property (e.g., 'pos', 'f', etc.) from the HDF5 dataset,
+        applying the current timestep and particle slices.
+        """
+        ds_path = f"particles/{self.particle_group}/{prop}/value"
+        ds = self.h5_file[ds_path]
+        return ds[self.ts_slice, self.pt_slice, :]
+
+    def select_particles_by_object(self, object_name, connectivity_value=0):
+        """
+        Convenience method to select particles based on a connectivity dataset.
+        For example, if you have a dataset at:
+            connectivity/ParticleHandle_to_{object_name}
+        this method selects the indices where the second column equals connectivity_value.
+        """
+        ds_name = f"connectivity/ParticleHandle_to_{object_name}"
+        connectivity_map = self.h5_file[ds_name][:]
+        particle_indices = connectivity_map[connectivity_map[:, 1] == connectivity_value][:, 0]
+        return H5DataSelector(self.h5_file, self.particle_group, ts_slice=self.ts_slice, pt_slice=particle_indices)
+    
+    def __getattr__(self, attr):
+        """
+        Called when an attribute lookup fails. Here we assume that if the attribute
+        is not found on the H5DataSelector instance, it is meant to be a property name.
+        For example, accessing `data.pos` is equivalent to `data.get_property('pos')`.
+        """
+        try:
+            # Avoid interfering with special attributes.
+            return self.__dict__[attr]
+        except KeyError:
+            # Try to return the property data.
+            return self.get_property(attr)
+
+    def __repr__(self):
+        return (f"<H5DataSelector(particle_group={self.particle_group}, "
+                f"ts_slice={self.ts_slice}, pt_slice={self.pt_slice})>")
+
+class TimestepAccessor:
+    """
+    A simple accessor that operates on a H5DataSelector object to update the timestep slice.
+    """
+    def __init__(self, sim_data):
+        self.sim_data = sim_data
+
+    def __getitem__(self, key):
+        # Return a new H5DataSelector with the timestep slice updated.
+        return H5DataSelector(self.sim_data.h5_file,
+                              self.sim_data.particle_group,
+                              ts_slice=key,
+                              pt_slice=self.sim_data.pt_slice)
+
+    def __repr__(self):
+        return f"<TimestepAccessor(ts_slice={self.sim_data.ts_slice})>"
+
+class ParticleAccessor:
+    """
+    A simple accessor that operates on a H5DataSelector object to update the particle slice.
+    """
+    def __init__(self, sim_data):
+        self.sim_data = sim_data
+
+    def __getitem__(self, key):
+        # Return a new H5DataSelector with the particle slice updated.
+        return H5DataSelector(self.sim_data.h5_file,
+                              self.sim_data.particle_group,
+                              ts_slice=self.sim_data.ts_slice,
+                              pt_slice=key)
+
+    def __repr__(self):
+        return f"<ParticleAccessor(pt_slice={self.sim_data.pt_slice})>"

--- a/pressomancy/object_classes/filament_class.py
+++ b/pressomancy/object_classes/filament_class.py
@@ -21,12 +21,12 @@ class Filament(metaclass=Simulation_Object):
         '''
         Initialisation of a filament object requires the specification of particle size, number of parts and a handle to the espresso system
         '''
-        Filament.numInstances += 1
         self.sys=config['espresso_handle']
         self.params=config
         self.associated_objects=self.params['associated_objects']
         self.build_function=RoutineWithArgs(func=make_centered_rand_orient_point_array,num_monomers=self.params['n_parts'])
         self.who_am_i = Filament.numInstances
+        Filament.numInstances += 1
         self.orientor = np.empty(shape=3, dtype=float)
         self.type_part_dict=PartDictSafe({key: [] for key in Filament.part_types.keys()})
 

--- a/pressomancy/object_classes/quadriplex_class.py
+++ b/pressomancy/object_classes/quadriplex_class.py
@@ -34,15 +34,15 @@ class Quartet(metaclass=Simulation_Object):
 
         assert config['type'] == 'solid' or config['type'] == 'broken', 'type must be either solid or broken!!!'
         assert config['n_parts'] == len(Quartet._referece_sheet), 'n_parts must be equal to the number of parts in the reference sheet!!!'
-        Quartet.numInstances += 1
         self.sys=config['espresso_handle']
         self.params=config
         if self.params['type'] == 'broken':
             assert self.params['bond_handle'] != None, 'broken quartets require a bond to be set!!!'
             Quartet.part_types.update({'circ': 28,
                   'squareA': 24, 'squareB': 25, 'cation': 27})
-       
         self.who_am_i = Quartet.numInstances
+        Quartet.numInstances += 1
+
         self.orientor = np.empty(shape=3, dtype=float)
         self.corner_particles = []
         self.type_part_dict=PartDictSafe({key: [] for key in Quartet.part_types.keys()})

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(
     test_suite="test",
     include_package_data=True,  # Include non-Python files like those in the resources folder
     install_requires=[
-        "numpy",  # Add any pip-installable dependencies here
+        "numpy", 
+         "h5py", # Add any pip-installable dependencies here
         # Don't include espresso since it's run via pypresso
     ],
     classifiers=[

--- a/test/test_IO.py
+++ b/test/test_IO.py
@@ -1,0 +1,80 @@
+import numpy as np
+import espressomd
+from create_system import sim_inst , BaseTestCase
+from pressomancy.simulation import Filament, Quartet, Quadriplex
+from pressomancy.helper_functions import BondWrapper
+from pressomancy.analysis import H5DataSelector
+import h5py
+import tempfile
+import os
+
+class IOTest(BaseTestCase):
+
+    N_avog = 6.02214076e23
+    sigma = 1.
+    rho_si = 0.6*N_avog
+    no_obj=30
+    N = int(no_obj/3)
+    vol = N/rho_si
+    box_l = pow(vol, 1/3)
+    _box_l = box_l/0.4e-09
+    box_dim = _box_l*np.ones(3)
+    _rho = N/pow(_box_l, 3)
+
+    sheets_per_quad = 3
+    part_per_filament = 2
+    no_crowders=10
+    part_per_ligand=2
+
+    def setUp(self) -> None:
+
+        sim_inst.set_sys()
+        quartet_configuration = Quartet.config.specify(espresso_handle=sim_inst.sys)
+        quartets = [Quartet(config=quartet_configuration) for x in range(self.no_obj)]
+        sim_inst.store_objects(quartets)
+
+        bond_quad = BondWrapper(espressomd.interactions.FeneBond(k=10., r_0=2., d_r_max=2*1.5))
+        grouped_quartets = [quartets[i:i+self.sheets_per_quad]
+                            for i in range(0, len(quartets), self.sheets_per_quad)]
+        quadriplex_configuration_list = [Quadriplex.config.specify(size=6., espresso_handle=sim_inst.sys, bond_handle=bond_quad, associated_objects=elem) for elem in grouped_quartets]
+
+        quadriplex = [Quadriplex(config=configuration) for configuration in quadriplex_configuration_list]
+        sim_inst.store_objects(quadriplex)
+
+        bond_pass = BondWrapper(espressomd.interactions.FeneBond(k=10., r_0=2., d_r_max=2*1.5))
+        grouped_quadriplexes = [quadriplex[i:i+self.part_per_filament:]
+                                for i in range(0, len(quadriplex), self.part_per_filament)]
+        filament_configuration_list = [Filament.config.specify(sigma=6,size=6*self.part_per_filament, n_parts=self.part_per_filament, espresso_handle=sim_inst.sys, bond_handle=bond_pass, associated_objects=elem) for elem in grouped_quadriplexes]
+        filaments = [Filament(config=configuration) for configuration in filament_configuration_list]
+        sim_inst.store_objects(filaments)
+        sim_inst.set_objects(filaments)
+        
+    def tearDown(self) -> None:
+        sim_inst.reinitialize_instance()
+        self.assertEqual(len(sim_inst.sys.part),0)
+
+    @staticmethod
+    def get_and_check(data,time):
+        data = H5DataSelector(data, particle_group="Filament")
+        properties=['pos','f','dip']
+        for prop in properties:
+            property_data=getattr(sim_inst.sys.part.all(),prop)
+            property_data_h5df=getattr(data.timestep[time].particles[:],prop)
+            assert np.allclose(property_data, property_data_h5df, rtol=1e-05, atol=1e-08), f'The vectors differ!, {property_data}, {property_data_h5df}'
+        for prop in ['id','type']:
+            property_data=getattr(sim_inst.sys.part.all(),prop)
+            property_data_h5df=getattr(data.timestep[time].particles[:],prop).flatten()
+            assert np.allclose(property_data, property_data_h5df, rtol=1e-05, atol=1e-08), f'The vectors differ!, {property_data}, {property_data_h5df}'
+
+    def test_IO_h5md(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            # Build a temporary filename inside the directory
+            h5_filename = os.path.join(tmpdirname, "testfile.h5")
+            with h5py.File(h5_filename, "w") as f:
+                hot_potato=sim_inst.inscribe_part_group_to_h5(group_type=Filament, h5_file=f)
+                for bookkeeper in range(10):
+                    sim_inst.sys.integrator.run(1)
+                    sim_inst.write_part_group_to_h5(config=hot_potato,time_step=0,h5_file=f)
+                    self.get_and_check(f,bookkeeper)
+
+        


### PR DESCRIPTION
Simulation class gained two new methods:

- inscribe_part_group_to_h5()
- write_part_group_to_h5()
that enable one to create a H5MD compliant H5 datastructure and to write to it (new timestep). The datastructure uses chunking and gzip compression to minimize memory requirements for data analysis (each timestep is a data chunk) and disk space requirements (level 4 compression).

The inscribe_part_group_to_h5() method creates a structure similar to:

data.h5
 ├── particles/
  │  ├── Crowder
  │   │   ├── id/step, time, value  (t, N)
  │   │   ├── type/step, time, value (t, N)
  │   │   ├── pos/step, time, value  (t, N, 3)
  │   │   ├── f/step, time, value    (t, N, 3)
  │   │   ├── dip/step, time, value  (t, N, 3)
  │  ├── Filament
  │   │   ├── id/step, time, value  (t, N)
  │   │   ├── type/step, time, value (t, N)
  │   │   ├── pos/step, time, value  (t, N, 3)
  │   │   ├── f/step, time, value    (t, N, 3)
  │   │   ├── dip/step, time, value  (t, N, 3)
  │
 ├── connectivity/
  │   ├── ParticleHandle_to_Crowder (N, 2)   # Maps particle to Crowder
  │   ├── ParticleHandle_to_Filament (N, 2)  # Maps particle to Filament

A connectivity map is aware of simulation object (metaclass=SimulationObject) ownership relationships so that a ParticleHandle is related to all objects it can be associated with. This is achieved via recursive calls to SimulationObject method get_owned_part() (returns flattened list of all particle handles that can be associated with the calling object and list of (class_name, who_am_i) tuples representing the ownership chain).

Introduced analysis subpackage with the H5DataSelector class. Provided that a H5 datafile has been made using the Simulation class I/O functionality, it provides a fast (no hidden nested loops), easy-to-use, and safe interface for data manipulation. Enables order of operations agnostic syntax:

data = H5DataSelector(f.h5, particle_group="Filament")
data.timestep[slice].particles[slice].prop
