### PR TITLE
Fix performance regression by dropping generators in partition_cubic_volume 

### DIFF
--- a/pressomancy/simulation.py
+++ b/pressomancy/simulation.py
@@ -204,6 +204,9 @@ class Simulation():
         """
         # Ensure all objects are of the same type.
         assert all(isinstance(item, type(objects[0])) for item in objects), "Not all items have the same type!"
+        # centeres, polymer_positions = partition_cubic_volume_oriented_rectangles(big_box_dim=self.sys.box_l, num_spheres=len(
+        #     filaments), small_box_dim=np.array([filaments[0].sigma, filaments[0].sigma, filaments[0].size]), num_monomers=filaments[0].n_parts)
+        # positions= generate_positions(len(objects), self.sys.box_l, 7.)
         if not self.part_positions:
             # First placement: generate exactly len(objects) positions.
             centeres, positions, orientations = partition_cubic_volume(

--- a/test/test_box_partitioning.py
+++ b/test/test_box_partitioning.py
@@ -1,6 +1,5 @@
 from pressomancy.simulation import partition_cubic_volume, get_neighbours, get_neighbours_cross_lattice
 from create_system import BaseTestCase
-import numpy as np
 
 class PartitioningTest(BaseTestCase):
     box_len=2.5
@@ -12,29 +11,16 @@ class PartitioningTest(BaseTestCase):
 
     def test_get_neighbours(self):
         control= {0: [2,], 1: [2,],2: [0, 1, 3, 4, ], 3: [2, ], 4: [2,]}
-        gen_part=partition_cubic_volume(self.box_len,self.num_vol_side,self.sph_diam, flag='norand')
-        sphere_centers_short=[]
-        while len(sphere_centers_short)<self.num_vol_side:  
-            pos, _,_ =next(gen_part)
-            sphere_centers_short.append(pos)
-
-        neigh=get_neighbours(np.array(sphere_centers_short),self.box_len,cuttoff=self.sph_diam)
+        sphere_centers_short, _,_=partition_cubic_volume(self.box_len,self.num_vol_side,self.sph_diam, flag='norand')
+        neigh=get_neighbours(sphere_centers_short,self.box_len,cuttoff=self.sph_diam)
         self.assertEqual(neigh,control,'the get_neighbour method failed to reproduce correct neighbour pairs for a single face of an fcc lattice')
 
     def test_get_neighbours_cross_lattice(self):
         
         control={0: [0, 2, 5, 6], 1: [1, 2, 5, 7], 2: [0, 1, 2, 3, 4, 5, 6, 7, 8], 3: [2, 3, 6, 8], 4: [2, 4, 7, 8]}
-        gen_part=partition_cubic_volume(self.box_len,self.num_vol_all,self.sph_diam,flag='norand')
-        sphere_centers_long=[]
-        while len(sphere_centers_long)<self.num_vol_all:  
-            pos, _,_ =next(gen_part)
-            sphere_centers_long.append(pos)
+        sphere_centers_long, _,_=partition_cubic_volume(self.box_len,self.num_vol_all,self.sph_diam,flag='norand')
 
-        gen_part=partition_cubic_volume(self.box_len,self.num_vol_side,self.sph_diam,flag='norand')
-        sphere_centers_short=[]
-        while len(sphere_centers_short)<self.num_vol_side:  
-            pos, _,_ =next(gen_part)
-            sphere_centers_short.append(pos)
+        sphere_centers_short, _,_=partition_cubic_volume(self.box_len,self.num_vol_side,self.sph_diam,flag='norand')
 
         neigh=get_neighbours_cross_lattice(sphere_centers_short,sphere_centers_long,self.box_len,cuttoff=self.sph_diam)
         self.assertEqual(neigh,control,'the get_neighbour method failed to reproduce correct neighbour pairs for a single face of an fcc lattice')  


### PR DESCRIPTION
 The commit 27cf060f8e4c1fa60c6620e76f982dcb63e61a1c addressed the issue where if one repartitions simulation box space, one could get less than required positions. This happened because the partitioning always returns the number of required volumes. However, a mask is used to filter positions that have cross-lattice overlaps, which was strictly less than the required number of particles. 

In solving this, it became clear that the memory footprint of   get_neighbours can become huge if a lattice constant is small compared to box size. The issue was fixed by moving the entire logic to generators so that data is generated per particle and only when needed. However, this introduced a perf regression. 

The simplest solution would be to use scipy kdtree to get neighbours. 
In order to avoid the dependency, we build a cell grid based on the cuffoff and a dict to look up adjacent cells. Neighbours are found based on this structure.  