### PR TITLE
Inscribe part wip

### DIFF
--- a/pressomancy/analysis/data_analysis.py
+++ b/pressomancy/analysis/data_analysis.py
@@ -198,7 +198,7 @@ class H5DataSelector:
         Returns:
             H5DataSelector: A new selector with the particle slice set to the selected indices.
         """
-        ds_name = f"connectivity/ParticleHandle_to_{object_name}"
+        ds_name = f"connectivity/{self.particle_group}/ParticleHandle_to_{object_name}"
         connectivity_map = self.h5_file[ds_name][:]
         particle_indices = connectivity_map[connectivity_map[:, 1] == connectivity_value][:, 0]
         particle_indices.sort()

--- a/pressomancy/analysis/data_analysis.py
+++ b/pressomancy/analysis/data_analysis.py
@@ -186,6 +186,24 @@ class H5DataSelector:
         ds_path = f"particles/{self.particle_group}/{prop}/value"
         ds = self.h5_file[ds_path]
         return ds[self.ts_slice, self.pt_slice, :]
+    
+    def get_connectivity_values(self, object_name):
+        """
+        Return the raw connectivity pairs for a given object, using the
+        ParticleHandle_to_<object_name> dataset.
+
+        Parameters
+        ----------
+        object_name : str
+            Name of the connected object type (e.g. "Filament").
+
+        Returns
+        -------
+        ndarray of shape (N, 2)
+            Array of [particle_id, object_index] pairs.
+        """
+        ds_path = f"connectivity/{self.particle_group}/ParticleHandle_to_{object_name}"
+        return set(self.h5_file[ds_path][:][:, -1])
 
     def select_particles_by_object(self, object_name, connectivity_value=0):
         """
@@ -204,6 +222,71 @@ class H5DataSelector:
         particle_indices.sort()
         particle_indices = particle_indices.tolist()  # Ensure a Python list is used.
         return H5DataSelector(self.h5_file, self.particle_group, ts_slice=self.ts_slice, pt_slice=particle_indices)
+    
+    def get_connectivity_map(self, parent_key, child_key):
+        """
+        Retrieve the raw (parent_id, child_id) array for a given object–object connectivity table.
+
+        Parameters
+        ----------
+        parent_key : str
+            Name of the parent object type (e.g. "Filament").
+        child_key : str
+            Name of the child object type (e.g. "Quadriplex").
+
+        Returns
+        -------
+        ndarray of shape (N, 2)
+            Array of [parent_id, child_id] pairs.
+        """
+        ds_path = f"connectivity/{self.particle_group}/{parent_key}_to_{child_key}"
+        return self.h5_file[ds_path][:]
+
+    def get_child_ids(self, parent_key, child_key, parent_id):
+        """
+        Return a sorted list of child object IDs connected to a given parent_id.
+
+        Parameters
+        ----------
+        parent_key : str
+            Name of the parent object type.
+        child_key : str
+            Name of the child object type.
+        parent_id : int
+            The who_am_i identifier of the parent object.
+
+        Returns
+        -------
+        List[int]
+            Sorted list of child who_am_i IDs belonging to the parent.
+        """
+        conn = self.get_connectivity_map(parent_key, child_key)
+        # Filter rows matching the parent_id, then extract child IDs
+        child_ids = conn[conn[:, 0] == parent_id, 1]
+        # Convert to Python ints and sort
+        return sorted(int(cid) for cid in child_ids)
+
+    def get_parent_ids(self, parent_key, child_key, child_id):
+        """
+        Return a sorted list of parent object IDs connected to a given child_id.
+
+        Parameters
+        ----------
+        parent_key : str
+            Name of the parent object type.
+        child_key : str
+            Name of the child object type.
+        child_id : int
+            The who_am_i identifier of the child object.
+
+        Returns
+        -------
+        List[int]
+            Sorted list of parent who_am_i IDs that link to the child.
+        """
+        conn = self.get_connectivity_map(parent_key, child_key)
+        parent_ids = conn[conn[:, 1] == child_id, 0]
+        return sorted(int(pid) for pid in parent_ids)
 
     def __getattr__(self, attr):
         """

--- a/pressomancy/simulation.py
+++ b/pressomancy/simulation.py
@@ -596,13 +596,17 @@ class Simulation():
 
         Raises
         ------
-        AssertionError
+        ValueError
             If `mode` is not one of 'NEW' or 'LOAD'.
-        AssertionError
+        ValueError
+            If `group_type` is not a list.
+        ValueError
             In 'LOAD' mode, if different groups have mismatched saved step counts.
         """
-
-        assert mode in ('NEW', 'LOAD'), f"Unknown mode: {mode}"
+        if not isinstance(group_type, list):
+            raise ValueError("group_type must be a list of classes.")
+        if mode not in ('NEW', 'LOAD'):
+            raise ValueError(f"Unknown mode: {mode}")
         self.io_dict['registered_group_type']=[grp_typ.__name__ for grp_typ in group_type]
 
         if mode=='NEW':

--- a/pressomancy/simulation.py
+++ b/pressomancy/simulation.py
@@ -124,7 +124,7 @@ class Simulation():
         self.part_positions=[]
         self.volume_size=None
         self.volume_centers=[]
-        self.io_dict={'h5_file': None,'properties':[('id',1), ('type',1), ('pos',3), ('f',3),('dip',3)],'flat_part_view':[],'registered_group_type': None}
+        self.io_dict={'h5_file': None,'properties':[('id',1), ('type',1), ('pos',3), ('f',3),('dip',3)],'flat_part_view':defaultdict(list),'registered_group_type': None}
         # self.sys=espressomd.System(box_l=box_dim) is added and managed by the singleton decrator!
 
     def set_sys(self, timestep=0.01, min_global_cut=3.0,have_quaternion=False):
@@ -545,118 +545,122 @@ class Simulation():
 
         return np.array(object_positions)
     
-    def collect_class_names(self, objects_to_register):
-        '''
-        Get a sorted set of class names in and within objects_to_register iterable
+    def collect_instances_recursively(self, roots):
+        """
+        Traverse each root in `roots` and return a flat preorder list
+        of every object reachable via `.associated_objects`.
+        Raises RuntimeError on any duplicate.
+        """
+        seen = set()
+        result = []
 
-        :param self: Description
-        :type self: 
-        :param objects_to_register: iterable containing objects using the SimulationObject metaclass
-        :type objects_to_register: 
-        :return: Description
-        :rtype: list[Any]'''
-        all_types = set()
         def traverse(obj):
-            if obj.associated_objects is not None:
-                for sub_obj in obj.associated_objects:
-                    class_name = obj.__class__.__name__
-                    all_types.add(class_name)
-                    traverse(sub_obj)
-            else:
-                class_name = obj.__class__.__name__
-                all_types.add(class_name)
+            if obj in seen:
+                raise RuntimeError(f"Duplicate object detected during recursion: {obj!r}")
+            seen.add(obj)
+            result.append(obj)
+            for child in getattr(obj, "associated_objects", []) or []:
+                traverse(child)
 
-        for obj in objects_to_register:
-            traverse(obj)
+        for root in roots:
+            traverse(root)
 
-        return sorted(all_types)
+        return result
 
     def inscribe_part_group_to_h5(self, group_type=None, h5_data_path=None,mode='NEW'):
         """
         Creates the HDF5 structure for this Crowder object.
         """
-        assert mode=='NEW' or mode=='LOAD','unknown mode!'
-        self.io_dict['registered_group_type']=group_type.__name__
-        logging.info(f"Inscribe: Creating group {self.io_dict['registered_group_type']}")
-        objects_to_register=[obj for obj in self.objects if isinstance(obj,group_type)]
-        
-        coordstuff=[]
-        for cr in objects_to_register:
-            part,coord=cr.get_owned_part()
-            self.io_dict['flat_part_view'].extend(part)
-            coordstuff.extend(coord)
-
-        total_part_num=len(self.io_dict['flat_part_view'])
-
+        assert mode in ('NEW', 'LOAD'), f"Unknown mode: {mode}"
+        self.io_dict['registered_group_type']=[grp_typ.__name__ for grp_typ in group_type]
         if mode=='NEW':
             self.io_dict['h5_file'] = h5py.File(h5_data_path, "w")
             par_grp = self.io_dict['h5_file'].require_group(f"particles")
-            data_grp = par_grp.require_group(self.io_dict['registered_group_type'])
-            connect_grp = self.io_dict['h5_file'].require_group(f"connectivity")
-            sorted_map=self.collect_class_names(objects_to_register)
-            for name in sorted_map:
-                connect_grp.create_dataset(f"ParticleHandle_to_{name}", shape=(total_part_num, 2), maxshape=(total_part_num, 2), dtype=np.int32)
-            sorted_map_copy_sans=sorted_map.copy()
-            for name in sorted_map_copy_sans:
-                nm=globals().get(name)
-                objects_local=[obj for obj in self.objects if isinstance(obj,nm)]
-                sorted_map=self.collect_class_names(objects_local)
-                sorted_map_copy=sorted_map.copy()
-                sorted_map_copy.remove(name)
-                if sorted_map_copy:
-                    for name_else in sorted_map_copy:
-                        objects_local_relevant=[x for x in objects_local if type(x.associated_objects[0])==globals().get(name_else)]
-                        group_type_num=len(objects_local_relevant)
-                        if group_type_num>0:
-                            connect_grp.create_dataset(f"{name}_to_{name_else}", shape=(group_type_num, 2), maxshape=(group_type_num, 2), dtype=np.int32)
-                            for iid, obj in enumerate(objects_local_relevant):
-                                ids=[x.who_am_i for x in obj.associated_objects]
-                                for el in coord:
-                                    dataset = connect_grp[f"{name}_to_{name_else}"]
-                                    dataset[0, :] = (part.id, el[1])
-            iid=0
-            for part,name_iid in zip(self.io_dict['flat_part_view'],coordstuff):
-                for el in name_iid:
-                    dataset = connect_grp[f"ParticleHandle_to_{el[0]}"]
-                    dataset[iid, :] = (part.id, el[1])
-                iid+=1
+            for grp_typ in group_type:
+                data_grp = par_grp.require_group(grp_typ.__name__)
+                connect_grp = self.io_dict['h5_file'].require_group(f"connectivity").require_group(grp_typ.__name__)
+                logging.info(f"Inscribe: Creating group {grp_typ.__name__} in HDF5 file.")
+                objects_to_register=[obj for obj in self.objects if isinstance(obj,grp_typ)]
             
-            for prop,dim in self.io_dict['properties']:
-                prop_group = data_grp.require_group(prop)
-                prop_group.create_dataset("step", shape=(0,), maxshape=(None,), dtype=np.int32)
-                prop_group.create_dataset("time", shape=(0,), maxshape=(None,), dtype=np.float32)
-                prop_group.create_dataset(
-                    "value",
-                    shape=(0, total_part_num, dim),  # Store all particles in a single dataset
-                    maxshape=(None, total_part_num, dim),
-                    dtype=np.float32,
-                    chunks=(1, total_part_num, dim),
-                    compression="gzip",
-                    compression_opts=4
-                )
+                coordination_indices=[]
+                for cr in objects_to_register:
+                    part,coord=cr.get_owned_part()
+                    self.io_dict['flat_part_view'][grp_typ.__name__].extend(part)
+                    coordination_indices.extend(coord)
+
+                total_part_num=len(self.io_dict['flat_part_view'][grp_typ.__name__])
+
+                # Create the connectivity for ParticleHandle to objects that own them.
+                grouped = defaultdict(list)
+                for part, coords in zip(self.io_dict['flat_part_view'][grp_typ.__name__], coordination_indices):
+                    for cls_name, idx in coords:
+                        grouped[cls_name].append((part.id, idx))
+
+                for cls_name in sorted(grouped):
+                    arr = np.array(grouped[cls_name], dtype=np.int32)
+                    connect_grp.create_dataset(
+                        f"ParticleHandle_to_{cls_name}",
+                        data=arr,
+                        dtype=np.int32,
+                        maxshape=(arr.shape)
+                    )
+                # Create the connectivity for objects that own each other
+                pair_buckets = defaultdict(list)
+                
+                for obj in self.collect_instances_recursively(objects_to_register):
+                    if not obj.associated_objects:
+                        continue
+                    left_name = obj.__class__.__name__
+                    for sub in obj.associated_objects:
+                        right_name = sub.__class__.__name__
+                        pair_buckets[(left_name, right_name)].append((obj.who_am_i, sub.who_am_i))
+
+                for (left_name, right_name) in sorted(pair_buckets):
+                    arr = np.array(pair_buckets[(left_name, right_name)], dtype=np.int32)
+                    ds = connect_grp.create_dataset(
+                        f"{left_name}_to_{right_name}",
+                        data=arr,
+                        dtype=np.int32,
+                        maxshape=(arr.shape)
+                    )
+                # Create the datasets for each property           
+                for prop,dim in self.io_dict['properties']:
+                    prop_group = data_grp.require_group(prop)
+                    prop_group.create_dataset("step", shape=(0,), maxshape=(None,), dtype=np.int32)
+                    prop_group.create_dataset("time", shape=(0,), maxshape=(None,), dtype=np.float32)
+                    prop_group.create_dataset(
+                        "value",
+                        shape=(0, total_part_num, dim),  # Store all particles in a single dataset
+                        maxshape=(None, total_part_num, dim),
+                        dtype=np.float32,
+                        chunks=(1, total_part_num, dim),
+                        compression="gzip",
+                        compression_opts=4
+                    )
             GLOBAL_COUNTER=0
         else:
             self.io_dict['h5_file'] = h5py.File(h5_data_path, "a")
             particles_group = self.io_dict['h5_file']["particles"]
-            data_grp = particles_group[self.io_dict['registered_group_type']]
-            dataset_val=data_grp["pos/value"]
+            data_grp = particles_group[self.io_dict['registered_group_type'][0]]
+            dataset_val = data_grp["pos/value"]
             GLOBAL_COUNTER=dataset_val.shape[0]
         return GLOBAL_COUNTER
         
     def write_part_group_to_h5(self, time_step=None):
         assert self.io_dict['h5_file']!=None,'storage file has not been inscribed!'
-        particles_group = self.io_dict['h5_file']["particles"]
-        data_grp = particles_group[self.io_dict['registered_group_type']]
-        
-        for prop,_ in self.io_dict['properties']:
-            dataset_val = data_grp[f"{prop}/value"]
-            step_dataset = data_grp[f"{prop}/step"]
-            time_dataset = data_grp[f"{prop}/time"]
-            step_dataset.resize((dataset_val.shape[0] + 1,))
-            time_dataset.resize((dataset_val.shape[0] + 1,))
-            dataset_val.resize((dataset_val.shape[0] + 1, dataset_val.shape[1], dataset_val.shape[2]))
-            step_dataset[-1] = time_step
-            time_dataset[-1] = time_step
-            dataset_val[-1, :, :] = np.array([np.atleast_1d(getattr(part, prop)) for part in self.io_dict['flat_part_view']], dtype=np.float32)
+        for grp_typ in self.io_dict['registered_group_type']:
+            particles_group = self.io_dict['h5_file']["particles"]
+            data_grp = particles_group[grp_typ]
+            for prop,_ in self.io_dict['properties']:
+                dataset_val = data_grp[f"{prop}/value"]
+                step_dataset = data_grp[f"{prop}/step"]
+                time_dataset = data_grp[f"{prop}/time"]
+                step_dataset.resize((dataset_val.shape[0] + 1,))
+                time_dataset.resize((dataset_val.shape[0] + 1,))
+                dataset_val.resize((dataset_val.shape[0] + 1, dataset_val.shape[1], dataset_val.shape[2]))
+                step_dataset[-1] = time_step
+                time_dataset[-1] = time_step
+                dataset_val[-1, :, :] = np.array([np.atleast_1d(getattr(part, prop)) for part in self.io_dict['flat_part_view'][grp_typ]], dtype=np.float32)
 
         logging.info(f"Successfully wrote timestep for {self.io_dict['registered_group_type']}.")
+

--- a/pressomancy/simulation.py
+++ b/pressomancy/simulation.py
@@ -596,6 +596,24 @@ class Simulation():
             sorted_map=self.collect_class_names(objects_to_register)
             for name in sorted_map:
                 connect_grp.create_dataset(f"ParticleHandle_to_{name}", shape=(total_part_num, 2), maxshape=(total_part_num, 2), dtype=np.int32)
+            sorted_map_copy_sans=sorted_map.copy()
+            for name in sorted_map_copy_sans:
+                nm=globals().get(name)
+                objects_local=[obj for obj in self.objects if isinstance(obj,nm)]
+                sorted_map=self.collect_class_names(objects_local)
+                sorted_map_copy=sorted_map.copy()
+                sorted_map_copy.remove(name)
+                if sorted_map_copy:
+                    for name_else in sorted_map_copy:
+                        objects_local_relevant=[x for x in objects_local if type(x.associated_objects[0])==globals().get(name_else)]
+                        group_type_num=len(objects_local_relevant)
+                        if group_type_num>0:
+                            connect_grp.create_dataset(f"{name}_to_{name_else}", shape=(group_type_num, 2), maxshape=(group_type_num, 2), dtype=np.int32)
+                            for iid, obj in enumerate(objects_local_relevant):
+                                ids=[x.who_am_i for x in obj.associated_objects]
+                                for el in coord:
+                                    dataset = connect_grp[f"{name}_to_{name_else}"]
+                                    dataset[0, :] = (part.id, el[1])
             iid=0
             for part,name_iid in zip(self.io_dict['flat_part_view'],coordstuff):
                 for el in name_iid:

--- a/test/test_IO.py
+++ b/test/test_IO.py
@@ -77,7 +77,7 @@ class IOTest(BaseTestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             # Build a temporary filename inside the directory
             h5_filename = os.path.join(tmpdirname, "testfile.h5")
-            GLOBAL_COUNTER=sim_inst.inscribe_part_group_to_h5(group_type=Filament, h5_data_path=h5_filename)
+            GLOBAL_COUNTER=sim_inst.inscribe_part_group_to_h5(group_type=[Filament,], h5_data_path=h5_filename)
             for _ in range(2):
                 sim_inst.sys.integrator.run(1)
                 sim_inst.write_part_group_to_h5(time_step=GLOBAL_COUNTER)


### PR DESCRIPTION
## What’s changed

1. **Expanded connectivity export**  
   - Previously we only saved **`ParticleHandle_to_<Object>`** tables. Now we also generate **`<ObjectA>_to_<ObjectB>`** datasets under `/connectivity/<GroupName>/`, capturing all object–object relationships.  
   - Connectivity is grouped by particle‑group, just like the time‑series data, for consistent on‑disk organization.

2. **Multi‑group inscription**  
   - **`inscribe_part_group_to_h5`** now accepts a **list** of `SimulationObject` types (instead of a single type). You can inscribe several particle‑groups in one call.  

3. **New data‑analysis helpers**  
   - **`get_connectivity_values(object_name)`** returns the set of all `who_am_i` IDs from the **ParticleHandle_to_<Object>** table.  
   - **`get_child_ids(parent_obj, child_obj, parent_id)`** returns all child object IDs for a given parent.  
   - **`get_parent_ids(parent_obj, child_obj, child_id)`** does the inverse.  

4. **Chaining selectors**  
   You can now drill down in a few lines:

   ```python
   import h5py
   data_file = h5py.File(data_path, "r")
   data = H5DataSelector(data_file, particle_group="Filament")

   # 1) List all filament IDs
   filament_ids = data.get_connectivity_values("Filament")

   for fid in filament_ids:
       # 2) Find all quadriplex IDs attached to this filament
       quad_ids = data.get_child_ids("Filament", "Quadriplex", parent_id=fid)

       # 3) Get all particles belonging to each quadriplex
       slices = [
           data.select_particles_by_object("Quadriplex", qid)
           for qid in quad_ids
       ]
       # `slices` is a list of H5DataSelectors you can slice further