### PR TITLE
Support rectangular box elastomer

### DIFF
--- a/pressomancy/object_classes/__init__.py
+++ b/pressomancy/object_classes/__init__.py
@@ -8,5 +8,8 @@ from pressomancy.object_classes.raspberry_sphere import RaspberrySphere
 from pressomancy.object_classes.tel_sequence import TelSeq
 from pressomancy.object_classes.part_class import GenericPart
 from pressomancy.object_classes.rigid_obj import GenericRigidObj
+from pressomancy.object_classes.point_dipole import PointDipolePermanent, PointDipoleSuperpara
+from pressomancy.object_classes.elastomer import Elastomer
+
 
 

--- a/pressomancy/object_classes/elastomer.py
+++ b/pressomancy/object_classes/elastomer.py
@@ -1,0 +1,707 @@
+import espressomd
+import numpy as np
+from collections import defaultdict
+from pressomancy.object_classes.object_class import Simulation_Object, ObjectConfigParams
+from pressomancy.object_classes.point_dipole import PointDipolePermanent
+from pressomancy.helper_functions import RoutineWithArgs, PartDictSafe, SinglePairDict, BondWrapper, add_box_constraints_func, remove_box_constraints_func, check_free_cuboid, fcc_lattice, generate_random_unit_vectors, normalize_vectors, get_neighbours_ordered, str_to_bool
+import logging
+import warnings
+import os
+import sys as sysos
+
+class Elastomer(metaclass=Simulation_Object):
+    '''
+    Class that contains elastomer relevant paramaters and methods. At construction one must pass an espresso handle becaouse the class manages parameters that are both internal and external to espresso. It is assumed that in any simulation instanse there will be only one type of a Elastomer. Therefore many relevant parameters are class specific, not instance specific.
+    '''
+    required_features=list()	
+    numInstances = 0
+    simulation_type=SinglePairDict('elastomer', 98)
+    part_types = PartDictSafe({'real':1, 'substrate': 98})
+    config = ObjectConfigParams(
+        box_E= None,
+        box_E_shift= np.array((0.,0.,0.)),
+        n_parts= None,
+        bond_type= "HarmonicBond",
+        bond_K_dist= "normal",
+        bond_K_lims= (0.01,0.1),
+        bond_cutoff= 5.,
+        max_bonds= 6,
+        seed= int.from_bytes(os.urandom(2), sysos.byteorder)
+        )
+
+    def __init__(self, config: ObjectConfigParams):
+        '''
+        Initialisation of a elastomer object requires the specification of particle size, number of parts and a handle to the espresso system
+        '''
+        self.sys=config['espresso_handle']
+        if config['box_E'] is None:
+            config['box_E'] = self.sys.box_l
+        config['box_E'] = np.asarray(config['box_E'])
+        if config['n_parts'] is None:
+            config['n_parts']= int( 0.2 * (np.prod(config['box_E']) /  4.18879) )
+            warnings.warn('monomer size assumed to be 1. and inferred number of particles from volume of Elastomer (to get 0.3 volume fraction)')
+        self.params=config
+        self.associated_objects=self.params['associated_objects']
+        if self.associated_objects is not None:
+            self.part_types.update({nam: typ for obj in self.associated_objects for nam, typ in obj.part_types.items()})
+            assert len(self.associated_objects) == self.params["n_parts"]
+        self.substrate=None
+        self.build_function=RoutineWithArgs(
+            func=self.build_Elastomer,
+            num_monomers=self.params['n_parts'],
+            monomer_size=self.params['size']*0.5
+            )
+        self.who_am_i = Elastomer.numInstances
+        Elastomer.numInstances += 1
+        self.type_part_dict=PartDictSafe({key: [] for key in Elastomer.part_types.keys()})
+    
+    def __del__(self):
+        Elastomer.numInstances -= 1
+
+    @classmethod
+    def load_gzip(cls, file, pressomancy_system, associated_class={PointDipolePermanent: (1.0, PointDipolePermanent.config)}):
+        """
+        Works only for point dipoles, ferro- or paramagnetic, for elastomer created with elastomer.save_gzip without associated objects.
+        """
+        espresso_handle = pressomancy_system.sys
+        assert Elastomer.numInstances < 1, "Failed to create elastomer from file. It is only possible to have an Elastomer instance at a time."
+        data = file.readline()
+        print("data eval", data)
+        config_tmp= eval(data, {"array": np.array, "np": np})
+        print("config_tmp", config_tmp)
+        data = file.readline().split()
+        assert data[0] == "None" and int(data[1])>0, "Not implemented for asssociated objects. Soon to come. Save using elastomer.save_gzip(). Also there must be at least one particle!! In the elastomer!!! Check the file."
+
+        assert np.isclose(sum(conc for conc, _ in associated_class.values()), 1.)
+
+        associated_objects = []
+
+        n_parts_left= config_tmp['n_parts']
+        keys_tmp= list(associated_class.keys())
+        for key in keys_tmp[:-1]:
+            n_parts_tmp= round(associated_class[key][0] * config_tmp['n_parts'])
+            associated_objects.extend([key(config=associated_class[key][1]) for _ in range(n_parts_tmp)])
+            n_parts_left -= n_parts_tmp
+        associated_objects.extend([keys_tmp[-1](config=associated_class[keys_tmp[-1]][1]) for _ in range(n_parts_left)])
+
+        config_E = Elastomer.config.specify(**config_tmp, associated_objects=associated_objects, espresso_handle=espresso_handle)
+        elastomer = cls(config=config_E)
+        pressomancy_system.store_objects([elastomer])
+
+        points= [] * config_tmp['n_parts']
+        orientations= [] * config_tmp['n_parts']
+        id_list= [] * config_tmp['n_parts']
+        fix_list= [] * config_tmp['n_parts']
+        # virtual_list= [] * config_tmp['n_parts']
+        bonds_list= [] * config_tmp['n_parts']
+
+        n_types = int(data[1])
+        for typ_i in range(n_types):
+            data = file.readline().split()
+            assert data[0]=="parts", "Not implemented for complex samples. Look at the save_gzip without any associated objects. That's the stuff"
+            typ = int(data[2])
+            n_parts_tmp = int(data[1])
+            for part_i in range(n_parts_tmp):
+                data = file.readline().split()
+                if typ == 98: # ignore substrate
+                    continue
+                id_list.append(int(data[0]))
+                points.append(list(map(float, data[1:4])))
+                orientations.append(list(map(float, data[4:7])))
+                fix_list.append(list(map(str_to_bool, data[7:10])))
+                # virtual_list.append(tuple(str_to_bool(data[10]), int(data[11])))
+                bonds_list.append(data[12:])
+
+        radius_not_good = associated_class[keys_tmp[-1]][1]['size'] / 2
+        
+        points= np.asarray(points)
+        orientations= np.asarray(orientations)
+        elastomer.set_associated_objects(sphere_radius=radius_not_good, sphere_centers=points, sphere_orientations=orientations)
+
+        id_to_idx= {}
+        vip_list= [None] * config_tmp['n_parts']
+        for i in range(config_tmp['n_parts']):
+            id_to_idx[id_list[i]] = i
+            vip_list[i] = elastomer.associated_objects[i].vip
+        for i, vip in enumerate(vip_list):
+            vip.fix = fix_list[i]
+            for part_bond in bonds_list[i]:
+                part_bond_split = part_bond.split(",")
+                elastic_bond = espressomd.interactions.HarmonicBond(k=float(part_bond_split[0]), r_0=float(part_bond_split[1]), r_cut=-1.0)
+                elastomer.sys.bonded_inter.add(elastic_bond)
+                vip_2 = vip_list[id_to_idx[int(part_bond_split[2])]]
+                vip.add_bond((elastic_bond, vip_2))
+
+        return elastomer
+    
+    def set_associated_objects(self, sphere_radius, sphere_centers, sphere_orientations):
+        assert self.params['n_parts'] == len(sphere_centers) == len(sphere_orientations)
+
+        orientations, points = build_function_generic(self, box_l=self.params['box_E'], num_children=self.params['n_parts'], children_centers=sphere_centers, children_orientations=sphere_orientations, children_size=sphere_radius)
+
+        pos=np.asarray(points)
+        ori=np.asarray(orientations)
+        assert check_free_cuboid(self.sys, self.params['box_E'], self.params['box_E_shift']), "Elastomer must be build on empty space. Adjust box_E and box_E_shift or remove non-elastomer particles to make space."
+        assert len(
+            pos) == self.params['n_parts'], 'there is a missmatch between the pos lenth and Elastomer n_parts'
+
+        assert self.params['n_parts'] == len(
+            self.associated_objects), " there doest seem to be enough particles stored!!! "
+        if not all(hasattr(obj, 'set_object') and callable(getattr(obj, 'set_object')) for obj in self.associated_objects):
+            raise TypeError("One or more objects do not implement a callable 'set_object'")
+        logic = (obj_el.set_object(pos_el, ori_el)
+                    for obj_el, pos_el, ori_el in zip(self.associated_objects, pos, ori))
+        for part in logic:
+            pass
+        
+        return self
+
+    def set_object(self, pos, ori):
+        '''
+        Sets the particles in espresso according to self.build_funciton. Particles created here are treated according to their class set_object functions. Indices of added particles stored in self.realz_indices.append attribute.
+
+        :param pos: np.array() | float, list of positions
+        :return: None
+
+        '''
+        pos=np.atleast_2d(pos)
+        assert np.all((pos >= self.params['box_E_shift']) & (pos <= self.params['box_E_shift'] + self.params['box_E'])), "particle positions are outisde of elastomer space. Make sure to use elastomer.params['box_E'] and elastomer.params['box_E_shift'] as inputs to the Simulation.set_objects."
+        assert check_free_cuboid(self.sys, self.params['box_E'], self.params['box_E_shift']), "Elastomer must be build on empty space. Adjust box_E and box_E_shift or remove non-elastomer particles to make space."
+        assert len(
+            pos) == self.params['n_parts'], 'there is a missmatch between the pos lenth and Elastomer n_parts'
+        if self.associated_objects is None:
+            dipm= 1.
+            logic = (self.add_particle(type_name='real',pos=pp, dip=(dipm * oo), rotation=(True, True, True)) for pp, oo in zip(pos, ori))
+        else:
+            assert self.params['n_parts'] == len(
+                self.associated_objects), " there doest seem to be enough particles stored!!! "
+            if not all(hasattr(obj, 'set_object') and callable(getattr(obj, 'set_object')) for obj in self.associated_objects):
+                raise TypeError("One or more objects do not implement a callable 'set_object'")
+            logic = (obj_el.set_object(pos_el, ori_el)
+                        for obj_el, pos_el, ori_el in zip(self.associated_objects, pos, ori))
+        for part in logic:
+            pass
+        
+        return self
+    
+    def build_Elastomer(self, center=None, sphere_radius=1., num_monomers=1, spacing=None, flag='rand'):
+        box_lengths= np.asarray(self.params['box_E'])
+        scaling = 1.0
+        
+        # Adjust scaling until we have enough sphere centers
+        while True:
+            sphere_centers = fcc_lattice(radius=sphere_radius, volume_sides=box_lengths, scaling_factor=scaling)
+            volumes_to_fill=len(sphere_centers)
+            logging.info('num_spheres_needed, num_spheres_got: %s', (num_monomers, volumes_to_fill))
+            if  volumes_to_fill>= num_monomers:
+                break
+            scaling -= 0.1
+        logging.info('scaling used: %s', scaling)
+
+        # Center point distribution in box
+        min_centers = np.min(sphere_centers, axis=0)
+        max_centers = np.max(sphere_centers, axis=0)
+        sphere_centers += self.params['box_E']/2 - (min_centers + max_centers)/2
+
+        # Randomly shuffle the available centers and select the required number of centers
+        take_index = np.arange(len(sphere_centers))
+        if flag=='rand':
+            np.random.shuffle(take_index)
+        take_index = take_index[:num_monomers]
+        sphere_centers=sphere_centers[take_index]
+
+        orientations, points = build_function_generic(self, box_l=box_lengths, num_children=num_monomers, children_centers=sphere_centers, children_size=sphere_radius)
+
+        return orientations, points
+    
+    def mix_elastomer_stuff(self, iter_multiplier=1, test=False):
+        if isinstance(self, list):
+            raise ValueError("Must be used on Elastomer object type")
+
+        # add iniziatilation process, to get a nice random distribution before bonding
+        if test:
+            n_inter_0 = 10
+            n_iter_1 = 0
+            timestep_iter_1 = 0.0001
+            self.sys.time_step = 0.01
+        else:
+            n_inter_0 = 100
+            n_iter_1 = int(2000000 * iter_multiplier)
+            timestep_iter_1 = 0.0001
+
+        old_time_step= float(self.sys.time_step)
+
+        # Add temporary box particles
+        types_M = tuple(typ for key, typ in self.part_types.items() if "real" in key)
+        add_box_constraints_func(sides=['no-sides'], top=(self.params['box_E'][2] + self.params['box_E_shift'][2]), bottom=self.params['box_E_shift'][2], inter='wca', types_=types_M, sys=self.sys)
+
+        # Make sure particles are not overlapping walls or substrate
+        self.sys.integrator.set_steepest_descent(f_max=0, gamma=100, max_displacement=0.1)
+        energy_non_bonded = self.sys.analysis.energy()['non_bonded']
+        count_while= 0
+        while energy_non_bonded > 0 and not test:
+            self.sys.integrator.run(n_inter_0)
+            energy_non_bonded = self.sys.analysis.energy()['non_bonded']
+            if count_while > 100 and energy_non_bonded < 0.1/self.params['n_parts']:
+                break
+        self.sys.integrator.set_vv()
+
+        # First relaxation (high T)
+        self.sys.thermostat.set_langevin(kT=0.5, gamma=10, seed=self.params['seed'])
+        self.sys.time_step = timestep_iter_1
+        self.sys.integrator.run(n_iter_1)
+
+        # Remove temporary box particles
+        remove_box_constraints_func(sys=self.sys)
+
+        self.sys.thermostat.turn_off()
+        self.sys.time_step = old_time_step
+        
+    
+    def cure_elastomer(self, fold_coord=True, test=False, test_bad=False):
+        if isinstance(self, list):
+            raise ValueError("Must be used on Elastomer object type")
+
+        # add iniziatilation process, to get a nice random distribution before bonding
+        if test:
+            n_inter_0 = 10
+        else:
+            n_inter_0 = 100
+
+        if fold_coord:
+            # raise NotImplementedError("Not tested.")
+            part_list= [part for typ_ in self.part_types for part in self.type_part_dict[typ_]]
+            for part in part_list:
+                pos_folded = part.pos_folded
+                part.pos = pos_folded
+
+        if self.substrate is not None:
+            # Stuck the bottom layer particles to the z=R_M plane
+            #  (restrict movement in z direction)
+            assert ( isinstance(self.substrate, espressomd.constraints.ShapeBasedConstraint) and isinstance(self.substrate.shape, espressomd.shapes.Wall) ) \
+             or ( isinstance(self.substrate, list) and all([isinstance(part, espressomd.particle_data.ParticleHandle) for part in self.substrate]) ) \
+            , "substrate must be None, an espresso wall constraint, or a list of particle handles. Use Elastomer.create_substrate to create valid substrate."         
+            z_subs_tmp= self.params['box_E_shift'][2]
+            if self.associated_objects is None:
+                z_tmp = z_subs_tmp + 0.5
+                for hndl in self.type_part_dict['real']:
+                    if hndl.pos[2] < (z_tmp + 0.25): # chose at which heights to capture Ms
+                        hndl.pos = [hndl.pos[0], hndl.pos[1], z_tmp]
+                        hndl.fix = [False, False, True]                
+            else:
+                for obj in self.associated_objects:
+                    r_M = obj.params['size'] / 2
+                    z_tmp =  z_subs_tmp + r_M
+                    for key, typ in obj.part_types.items():
+                        if "real" in key:
+                            hndls= obj.type_part_dict[typ]
+                            for hndl in hndls:
+                                if hndl.pos[2] < (z_tmp + r_M/4): # chose at which heights to capture Ms
+                                    hndl.pos = [hndl.pos[0], hndl.pos[1], z_tmp]
+                                    hndl.fix = [False, False, True]
+
+            types_M = tuple(typ for key, typ in self.part_types.items() if "real" in key)
+            add_box_constraints_func(sides=['no-sides'], top=(self.params['box_E'][2] + self.params['box_E_shift'][2]), bottom=self.params['box_E_shift'][2], inter='wca', types_=types_M, sys=self.sys)
+
+            old_time_step= float(self.sys.time_step)
+
+            # Relaxation with substrate (low T)
+            self.sys.thermostat.set_langevin(kT=1E-3, gamma=100, seed=self.params['seed'])
+            self.sys.time_step=0.001
+            energy_non_bonded = self.sys.analysis.energy()['non_bonded']
+            n_count=0
+            while energy_non_bonded > 0 and n_count < 100 and not test:
+                self.sys.integrator.run(n_inter_0)
+                energy_non_bonded = self.sys.analysis.energy()['non_bonded']
+                n_count+=1
+
+            remove_box_constraints_func(sys=self.sys)
+            self.sys.thermostat.turn_off()
+            self.sys.time_step = old_time_step
+
+        # Bond particles
+        r_catch = self.params['bond_cutoff']
+        max_bonds = self.params['max_bonds']
+        bond_k = self.params['bond_K_lims']
+        dist = self.params['bond_K_dist']
+        n_bonds_if_0 = 3
+        r_catch_if_0 = r_catch if not test_bad else None
+
+        if self.params['bond_type'] == "HarmonicBond":
+            _, n_bonds_dict = self.random_harmonic_bonds(r_catch, bond_k, max_bonds, r_cut=-1, dist=dist, std_scaling=6)
+            logging.info("Added most bonds")
+            lonely_M = []
+            for id, n_bonds in n_bonds_dict.items():
+                if n_bonds == 0:
+                    lonely_M.append(id)
+            self.bond_to_neighbors(parts=self.sys.part.by_ids(lonely_M), n_nghb=n_bonds_if_0, bond_k=bond_k, r_cut=-1, r_catch=r_catch_if_0, dist=dist, std_scaling=6)
+
+    def relax_langevin(self, iter_multiplier=1, kT=1E-3, gamma=10, time_step=0.001, test=False):
+        if isinstance(self, list):
+            raise ValueError("Must be used on Elastomer object type")
+
+        # add iniziatilation process, to get a nice random distribution before bonding
+        if test:
+            n_iter = 0
+        else:
+            n_iter = int(200000 * iter_multiplier)
+
+        old_time_step= float(self.sys.time_step)
+        self.sys.time_step = time_step
+
+        self.sys.thermostat.set_langevin(kT=kT, gamma=gamma, seed=self.params['seed'])
+        self.sys.integrator.run(n_iter)
+        self.sys.time_step = old_time_step
+        self.sys.thermostat.turn_off()
+
+    def save_gzip(self, file):
+        line_save=""
+        params_save= {key: value for key, value in self.params.items() if key not in ("associated_objects", "espresso_handle") }
+        print("params_save", params_save)
+        line_save = str(params_save) + "\n"
+        file.write(line_save.encode())
+
+        if self.associated_objects is not None:
+            raise NotImplementedError("Will implement soon-ish.")
+        else:
+            file.write(f"None {len(self.type_part_dict.keys())}\n".encode())
+            for typ, hndls in self.type_part_dict.items():
+                line_save = f"parts {len(hndls)} {self.part_types[typ]}\n"
+                for part in hndls:
+                    line_save += f"{part.id} {part.pos[0]} {part.pos[1]} {part.pos[2]}"
+                    line_save += f" {part.dip[0]} {part.dip[1]} {part.dip[2]}"
+                    line_save += f" {part.fix[0]} {part.fix[1]} {part.fix[2]}"
+                    line_save += f" {part.is_virtual()} {part.vs_relative[0]}"
+                    for bond in part.bonds:
+                        line_save += f" {bond[0].k},{bond[0].r_0},{bond[1]}"
+                    line_save += "\n"
+                file.write(line_save.encode())
+
+    def add_anchors(self,type_keys='all'): #TO BE DONE FOR ROTATION CONSTRAINTS
+        '''
+        Adds virtual particles at top and bottom of a particle with size sigma, as given by their director (aligned with the dipole moments for magnetic particles).
+        Logic firstly adds front anchors and then back anchors, so there is a consistent logic to track ids. Indices of particles added here are stored in self.fronts_indices/self.backs_indices attributes respectively.
+
+        :None:
+
+        '''
+        if type_keys == 'all':
+            type_keys = tuple(typ for key, typ in self.part_types.items() if "real" in key)
+        if self.associated_objects is not None:
+            raise NotImplementedError('add_anchors is still WIP for generic objects')
+        else:
+            self.fronts_indices=[]
+            self.backs_indices=[]
+
+            handles = self.type_part_dict['real']
+
+            logic_front = ((self.add_particle(type_name='virt', pos=part.pos + 0.5 * self.params['size'] * part.director, rotation=(False, False, False)), part) for part in handles)
+            logic_back  = ((self.add_particle(type_name='virt', pos=part.pos - 0.5 * self.params['size'] * part.director, rotation=(False, False, False)), part) for part in handles)
+
+            for part_front, part in logic_front:
+                part_front.vs_auto_relate_to(part)
+                self.fronts_indices.append(part_front.id)
+
+            for part_back, part in logic_back:
+                part_back.vs_auto_relate_to(part)
+                self.backs_indices.append(part_back.id)
+            logging.info(f'anchors added for Elastomer particles: {self.who_am_i}')
+
+    def random_harmonic_bonds(self, r_catch, bond_k=(0.001, 0.01), max_bonds=None, r_cut=-1, dist="normal", std_scaling=6):
+        """
+        Randomly generate harmonic bonds between particle pairs within elastomer
+
+        This method creates harmonic (elastic) bonds between random pairs of particles that are within 
+        a specified maximum bonding distance (`r_catch`). The spring constant `k` for each bond is sampled from a truncated normal distribution defined over the interval `bond_k`, centered at its midpoint, with standard deviation equal to `(bond_k[1] - bond_k[0]) / std_scaling`.
+
+        Parameters:
+            r_catch (float): Maximum distance allowed between two particles to form a bond.
+            bond_k (float or tuple of float, optional): Elastic constant bounds for the bonds.
+                If a single number is given, all bonds use that value. If a tuple is provided,
+                values are sampled from a truncated normal distribution between the two values.
+                Defaults to (0.001, 0.01).
+            max_bonds (int, optional): Maximum number of bonds each particle can form. 
+                Defaults to all of the allowed bonds.
+            std_scaling (float, optional): Scaling factor used to control the spread (std deviation) 
+                of the `k` distribution. Higher values yield a narrower distribution. Default is 6.
+
+        Returns:
+            tuple:
+                - total_bonds (int): Total number of harmonic bonds created.
+                - n_bonds_dict (dict): Dictionary mapping each particle type pair to the number of 
+                bonds created for that pair.
+
+        Notes:
+            - Bonds will be stores in either of the two particles bonded. There is no way to predict this.
+            - Assumes a cubic simulation box (all box dimensions must be equal).
+            - Applies periodic boundary conditions (PBC) when computing distances.
+            - Each bond is added symmetrically and uniquely per particle pair.
+            - Requires `get_neighbours` to provide a mapping of nearby particle IDs.
+        """
+        if self.substrate is not None:
+            old_periodicity = np.copy(self.sys.periodicity)
+            self.sys.periodicity = [True, True, False]
+
+        ids=[]
+        if self.associated_objects is not None:
+            for obj in self.associated_objects:
+                ids.extend([p.id for type_name, p_list in obj.type_part_dict.items() if isinstance(type_name, str) and "real" in type_name for p in p_list])
+        else:
+            ids = [p.id for p in self.type_part_dict["real"]]
+        particles = self.sys.part.by_ids(ids)
+
+        if max_bonds is None:
+            max_bonds = len(particles)
+
+        box_size= self.sys.box_l[0]
+        if self.sys.periodicity[2]:
+            assert all(ele == box_size for ele in self.sys.box_l[1:]), "method assumes cubic box for system PBC"
+
+        if isinstance(bond_k, (float, int)):
+            bond_k = [bond_k, bond_k]
+        assert (len(bond_k)==2
+                and bond_k[1]-bond_k[0]>=0
+               ), "method assumes bond_k to be either a number, or an interval represented by a tuple of the form (min, max)"
+        
+        assert r_cut > r_catch or r_cut == -1, "r_cut must be larger than any bond lenght. (default -1)"
+        
+        if dist in ("normal", "norm", "gaussian", "gauss"):
+            mean_tmp = ( bond_k[1] + bond_k[0] ) / 2
+            std_tmp = ( bond_k[1] - bond_k[0] ) / std_scaling
+
+            dist_func = np.random.normal
+            dist_kwargs = {'loc': mean_tmp, 'scale': std_tmp}
+        else:
+            raise ValueError(f"Tried to use unsupported distribution for elastomer bond strenght: '{dist}'. Supported distributions: 'normal'.")
+
+        n_bonds_dict= defaultdict(int)
+
+        pair_dict = get_neighbours_ordered(particles.pos, box_size, r_catch, map_indices=particles.id, periodicity=self.sys.periodicity)
+
+        n_bonds= 0
+        for particle in particles:
+            id1 = particle.id
+
+            bonds_per_HM = n_bonds_dict[id1]
+            if bonds_per_HM >= max_bonds:
+                continue
+            
+            # remove neighbors that already have max bonds
+            pair_dict_safe = pair_dict[id1].copy()
+            for id2 in pair_dict_safe:
+                if n_bonds_dict[id2] >= max_bonds:
+                    pair_dict[id1].remove(id2)
+
+            ids2 = np.random.choice(pair_dict[id1], min(len(pair_dict[id1]), max_bonds-bonds_per_HM), replace=False)
+
+            for id2 in ids2:
+
+                assert len(self.sys.part.by_id(id2).bonds) < max_bonds, f"len{len(self.sys.part.by_id(id2).bonds)}, n_bond{n_bonds_dict[id2]}"
+
+                particle_nghb = self.sys.part.by_id(id2)
+
+                r_12 = self.sys.distance(p1=particle, p2=particle_nghb)
+
+                k_12= bond_k[0] - 1
+                while k_12<bond_k[0] or k_12>bond_k[1]:
+                    k_12 = dist_func(**dist_kwargs)
+                elastic_bond = espressomd.interactions.HarmonicBond(r_0=r_12, k=k_12, r_cut=r_cut)
+
+                self.sys.bonded_inter.add(elastic_bond)
+                self.sys.part.by_id(id1).add_bond((elastic_bond, id2))
+
+                n_bonds_dict[id1] += 1; n_bonds_dict[id2] += 1 # keep count of n bonds
+                if id1 in pair_dict[id2]:
+                    pair_dict[id2].remove(id1) # remove already bonded pairs from pair_dict
+
+                assert r_12<=r_catch
+
+            n_bonds+= n_bonds_dict[id1]
+
+        if self.substrate is not None:
+            self.sys.periodicity = old_periodicity
+
+        logging.info([(key, x) for key, x in n_bonds_dict.items() if x!=6])
+
+        return sum(n_bonds_dict.values()), n_bonds_dict
+    
+    def bond_to_neighbors(self, parts, n_nghb=3, bond_k=(0.001,0.01), r_catch=None, r_cut=-1, dist="normal", std_scaling=6):
+        """bond to n nearest neighbors, with elastic bond"""
+
+        if self.substrate is not None:
+            old_periodicity = np.copy(self.sys.periodicity)
+            self.sys.periodicity = [True, True, False]
+
+        box_size= self.sys.box_l[0]
+        if self.sys.periodicity[2]:
+            assert all(ele == box_size for ele in self.sys.box_l[1:]), "method assumes cubic box for system PBC"
+
+        if isinstance(bond_k, (float, int)):
+            bond_k = [bond_k, bond_k]
+        assert (len(bond_k)==2
+                and bond_k[1]-bond_k[0]>=0
+               ), "method assumes bond_k to be either a number, or an interval represented by a tuple of the form (min, max)"
+        
+        if r_catch is None:
+            r_catch = box_size/2
+        assert r_cut > r_catch or r_cut == -1, "r_cut must be larger than any bond lenght. (default -1)"
+        
+        if dist in ("normal", "norm", "gaussian", "gauss"):
+            mean_tmp = ( bond_k[1] + bond_k[0] ) / 2
+            std_tmp = ( bond_k[1] - bond_k[0] ) / std_scaling
+
+            dist_func = np.random.normal
+            dist_kwargs = {'loc': mean_tmp, 'scale': std_tmp}
+        else:
+            raise ValueError(f"Tried to use unsupported distribution for elastomer bond strenght: '{dist}'. Supported distributions: 'normal'.")
+        
+        neighbours_dict = get_neighbours_ordered(parts.pos, box_size, r_catch, map_indices=parts.id, periodicity=self.sys.periodicity)
+        for id1 in parts.id:
+            particle = self.sys.part.by_id(id1)
+            n_count = 0
+            for id2 in neighbours_dict[id1]:
+                if n_count == n_nghb:
+                    break
+
+                particle_nghb = self.sys.part.by_id(id2)
+
+                r_12 = self.sys.distance(p1=particle, p2=particle_nghb)
+
+                mean_tmp = ( bond_k[1] + bond_k[0] ) / 2
+                std_tmp = ( bond_k[1] - bond_k[0] ) / 6
+                k_12= bond_k[0] - 1
+                while k_12<bond_k[0] or k_12>bond_k[1]:
+                    k_12 = dist_func(**dist_kwargs)
+                elastic_bond = espressomd.interactions.HarmonicBond(r_0=r_12, k=k_12, r_cut=r_cut)
+
+                self.sys.bonded_inter.add(elastic_bond)
+                self.sys.part.by_id(id1).add_bond((elastic_bond, id2))
+
+                assert r_12<=r_catch
+
+                n_count+= 1
+
+            assert n_count == n_nghb
+        
+        if self.substrate is not None:
+            self.sys.periodicity = old_periodicity
+
+    def create_substrate(self, geometry: str = 'part'):
+        if self.substrate is None:
+            if geometry == 'wall':
+                self.create_substrate_wall()
+            else:
+                self.create_substrate_part()
+        else:
+            warnings.warn("Substrate already set. Will ignore this call.")
+
+    def remove_substrate(self, geometry: str = 'part'):
+        if self.substrate is not None:
+            if geometry == 'wall':
+                self.remove_substrate_wall()
+            else:
+                self.remove_substrate_part()
+        else:
+            warnings.warn("Substrate not yet set. Will ignore this call.")
+
+    def create_substrate_part(self):
+        n_substrate_x = int(np.ceil(self.params['box_E'][0]))
+        n_substrate_y = int(np.ceil(self.params['box_E'][1]))
+        n_substrate= n_substrate_x * n_substrate_y
+        pos_x, pos_y = np.meshgrid( np.linspace(0.5, self.params['box_E'][0]-0.5, n_substrate_x),
+                                    np.linspace(0.5, self.params['box_E'][1]-0.5, n_substrate_y) )
+        pos = np.column_stack((pos_x.ravel(), pos_y.ravel(), ( np.zeros(n_substrate) - 0.5 + self.params['box_E_shift'][2] ) ))
+
+        substrate_list= []
+        for i in range(n_substrate):
+            part_hndl = self.add_particle(type_name="substrate", pos=pos[i], type=self.part_types['substrate'], virtual=True, fix=[True,True,True])
+            substrate_list.append(part_hndl)
+        self.substrate = substrate_list
+
+        for key, typ in self.part_types.items():
+            if "real" in key:
+                sigma = (0.5 + self.sys.non_bonded_inter[typ,typ].wca.sigma/2) / 2**(1/6)
+                if sigma < 0.001:
+                    raise ValueError(f"Interaction of type {typ} with wall is 0, has these particles have no interaction defined. If you would like to have no interactions between particles, but only with wall, then hange this function or do it with normal espresso constraints.")
+                self.sys.non_bonded_inter[self.part_types['substrate'], typ].wca.set_params(epsilon=1E6, sigma=sigma)
+        
+    def remove_substrate_part(self):
+        for part in self.substrate:
+            part.remove()
+        self.substrate = None
+
+        for key, typ in self.part_types.items():
+            if "real" in key:
+                self.sys.non_bonded_inter[self.part_types['substrate'], typ].wca.deactivate()
+
+
+    def create_substrate_wall(self):
+        types_M = tuple(typ for key, typ in self.part_types.items() if "real" in key)
+        wall_constraints = add_box_constraints_func(bottom=self.params['box_E_shift'][2], wall_type=self.part_types['substrate'], inter='wca', types_=types_M, sys=self.sys)
+        self.substrate = wall_constraints[0]
+        
+    def remove_substrate_wall(self):
+        remove_box_constraints_func(wall_type=self.part_types['substrate'], sys=self.sys)
+        self.substrate = None
+
+
+# Make generic build funciton to recursively call objects build functions
+def build_function_generic(parent_obj, box_l, num_children, children_centers, children_size, spacing=None, children_orientations=None):
+        # copy from partition cuboid volume
+        points_list = [None] * num_children
+        orientations_list = [None] * num_children
+
+        if children_orientations is None:
+            children_orientations = random_like_nested_3d_vectors(children_centers)
+
+        if parent_obj.associated_objects is None:
+            return children_orientations, children_centers
+        else:
+            children_handels = [obj for obj in parent_obj.associated_objects]
+
+            assert np.all(box_l[1]==box_l[0]), "this methods assumes square x-y box base for n_monores > 1"
+            box_length = box_l[0]
+            grouped_positions = defaultdict(list)
+            #grouped_volumes is a dictionary that contains all neighouring lattice sites sphere_diameter  
+            grouped_volumes=get_neighbours_ordered(children_centers,volume_side=box_length,cuttoff=children_size, periodicity=parent_obj.sys.periodicity)
+            for i, (child_obj, center, ori) in enumerate(zip(children_handels, children_centers, children_orientations)):
+                if hasattr(child_obj, "routine_per_volume"):
+                    raise NotImplementedError("Not yet implemented.")
+                else:
+                    # temporary fix
+                    points_list[i] = center
+                    orientations_list[i] = ori
+
+            return orientations_list, points_list
+        
+def random_like_nested_3d_vectors(item, rng=None):
+    """
+    Recursively generate random 3D unit vectors,
+    matching the shape of nested lists, tuples, or arrays.
+    - Lists/tuples of len==3 with all numbers => treated as vector and replaced by a random unit vector.
+    - NumPy arrays with last dimension == 3 => generate array of random unit vectors with same shape.
+    - Otherwise recurse.
+    Raises error if a scalar or other unsupported leaf is found.
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+    
+    if isinstance(item, (list, tuple)):
+        # Check if it is a 3D vector (leaf)
+        if len(item) == 3 and all(isinstance(x, (float, int)) for x in item):
+            return generate_random_unit_vectors(1).flatten().tolist()
+        else:
+            return [random_like_nested_3d_vectors(sub, rng) for sub in item]
+    
+    elif isinstance(item, np.ndarray):
+        if item.shape[-1] != 3:
+            raise ValueError(f"Expected last dimension to be 3 for 3D vectors, got shape {item.shape}")
+        
+        n_vectors = np.prod(item.shape[:-1])
+        vectors = generate_random_unit_vectors(n_vectors)
+        vectors = vectors.reshape(item.shape)
+        # Just to be sure normalize (your function is safe)
+        return normalize_vectors(vectors, axis=-1)
+
+    else:
+        raise ValueError(f"Expected last dimension to be 3 for 3D vectors, got {item}")

--- a/pressomancy/object_classes/point_dipole.py
+++ b/pressomancy/object_classes/point_dipole.py
@@ -1,0 +1,89 @@
+from pressomancy.object_classes.object_class import Simulation_Object, ObjectConfigParams 
+from pressomancy.helper_functions import PartDictSafe, SinglePairDict
+
+class PointDipolePermanent(metaclass=Simulation_Object):
+    '''
+    Class that contains permanent magnetic point dipole particles relevant paramaters and methods. At construction one must pass an espresso handle because the class manages parameters that are both internal and external to espresso. It is assumed that in any simulation instanse there will be only one type of a PointDipolePermanent. Therefore many relevant parameters are class specific, not instance specific.
+    '''
+
+    required_features=['DIPOLES']	
+    numInstances = 0
+    simulation_type= SinglePairDict('point_dipole_permanent', 3)
+    part_types = PartDictSafe({'pdp_real': 61})
+    config = ObjectConfigParams(
+         dipm=1.
+    )
+
+    def __init__(self, config: ObjectConfigParams):
+        '''
+        Initialisation of a PointDipolePermanent object requires the specification of particle size and a handle to the espresso system
+        '''
+        self.sys=config['espresso_handle']
+        self.params=config
+        PointDipolePermanent.numInstances += 1
+        self.who_am_i = PointDipolePermanent.numInstances
+        self.associated_objects=config['associated_objects']
+        self.type_part_dict=PartDictSafe({key: [] for key in PointDipolePermanent.part_types.keys()})
+        assert self.associated_objects is None, "Point dipoles can not have associated objects. They are singular particles, as basic as possible."
+
+    def set_object(self,  pos, ori):
+        '''
+        Sets a n_parts sequence of particles in espresso, asserting that the dimensionality of the pos paramater passed is commesurate with n_part.Using a generator object with the particle enumeration logic, and a try catch paradigm. Particles created here are treated as real, non_magnetic, with enabled rotations. Indices of added particles stored in self.realz_indices.append attribute. Orientation of filament stored in self.orientor = self.get_orientation_vec()
+
+        :param pos: np.array() | float, list of positions
+        :return: None
+
+        '''
+        dipm= self.params['dipm']
+        hndl = self.add_particle(type_name='pdp_real', pos=pos, rotation=[True, True, True], dip=(dipm * ori))
+
+        # Very Important Particle. To use to bond, calculate distances, and other Very Important Things. Usually at the center of mass, and usually a real particle
+        self.vip = hndl
+
+        return self
+    
+class PointDipoleSuperpara(metaclass=Simulation_Object):
+    '''
+    Class that contains superparamagnetic point dipole particles relevant paramaters and methods. At construction one must pass an espresso handle because the class manages parameters that are both internal and external to espresso. It is assumed that in any simulation instanse there will be only one type of a PointDipoleSuperpara. Therefore many relevant parameters are class specific, not instance specific.
+
+    Requires to run a magnetization function every step. Eg. system.magnetize()
+    '''
+
+    required_features=['DIPOLES', 'DIPOLE_FIELD_TRACKING']	
+    numInstances = 0
+    simulation_type= SinglePairDict('point_dipole_superpara', 4)
+    part_types = PartDictSafe({'pds_real': 62, 'pds_virt': 666})
+    config = ObjectConfigParams(
+         dipm=1.
+    )
+
+    def __init__(self, config: ObjectConfigParams):
+        '''
+        Initialisation of a PointDipoleSuperpara object requires the specification of particle size and a handle to the espresso system
+        '''
+        self.sys=config['espresso_handle']
+        self.params=config
+        PointDipoleSuperpara.numInstances += 1
+        self.who_am_i = PointDipoleSuperpara.numInstances
+        self.associated_objects=config['associated_objects']
+        self.type_part_dict=PartDictSafe({key: [] for key in PointDipoleSuperpara.part_types.keys()})
+        assert self.associated_objects is None, "Point dipoles can not have associated objects. They are singular particles, as basic as possible."
+
+    def set_object(self,  pos, ori):
+        '''
+        Sets a n_parts sequence of particles in espresso, asserting that the dimensionality of the pos paramater passed is commesurate with n_part.Using a generator object with the particle enumeration logic, and a try catch paradigm. Particles created here are treated as real, non_magnetic, with enabled rotations. Indices of added particles stored in self.realz_indices.append attribute. Orientation of filament stored in self.orientor = self.get_orientation_vec()
+
+        :param pos: np.array() | float, list of positions
+        :return: None
+
+        '''
+        particl_real=self.add_particle(type_name='pds_real', pos=pos, rotation=[True, True, True], director=ori)
+        
+        particl_virt=self.add_particle(type_name='pds_virt', pos=pos, rotation=[False, False, False], dip=(ori * 1e-6))
+        particl_virt.vs_auto_relate_to(particl_real)
+
+        # Very Important Particle. To use to bond, calculate distances, and other Very Important Things. Usually at the center of mass, and usually a real particle
+        self.vip = particl_real
+
+        return self
+    

--- a/pressomancy/simulation.py
+++ b/pressomancy/simulation.py
@@ -236,7 +236,7 @@ class Simulation():
             if len(self.part_positions)== 0:
                 # First placement: generate exactly len(objects) positions.
                 centeres, positions, orientations = partition_cubic_volume(
-                    box_length=self.sys.box_l[0],
+                    box_lengths=self.sys.box_l,
                     num_spheres=len(objects),
                     sphere_diameter=objects[0].params['size'],
                     routine_per_volume=objects[0].build_function
@@ -249,7 +249,7 @@ class Simulation():
                 factor = 1
                 while True:
                     centeres, positions, orientations = partition_cubic_volume(
-                        box_length=self.sys.box_l[0],
+                        box_lengths=self.sys.box_l,
                         num_spheres=len(objects) * factor,
                         sphere_diameter=objects[0].params['size'],
                         routine_per_volume=objects[0].build_function
@@ -261,7 +261,7 @@ class Simulation():
                         other_lattice_centers=self.volume_centers[0],
                         other_lattice_grouped_part_pos=self.part_positions[0],
                         other_lattice_diam=self.volume_size,
-                        box_len=self.sys.box_l[0]
+                        box_lengths=self.sys.box_l
                         )
                     mask=[key for key,val in res.items() if all(val)]
                     positions=positions[mask]
@@ -317,7 +317,8 @@ class Simulation():
         logging.info(f'part types available {self.part_types.keys()} ')
         logging.info(f'WCA interactions initiated for keys: {key}')
         for key_el, key_el2 in combinations_with_replacement(key, 2):
-            self.sys.non_bonded_inter[self.part_types[key_el], self.part_types[key_el2]
+            self.sys.non_bonded_inter[
+                self.part_types[key_el], self.part_types[key_el2]
                                       ].wca.set_params(epsilon=wca_eps, sigma=sigma)
 
     def set_steric_custom(self, pairs=[(None, None),], wca_eps=[1.,], sigma=[1.,]):

--- a/samples/mae-BoS.py
+++ b/samples/mae-BoS.py
@@ -1,0 +1,140 @@
+import espressomd
+import espressomd.magnetostatics
+import espressomd.checkpointing
+
+espressomd.assert_features(['WCA', 'ROTATION', 'DIPOLES', 'DP3M',
+                            'VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE',
+                            'EXTERNAL_FORCES'])
+
+from pressomancy.simulation import Simulation, Elastomer, PointDipolePermanent, PointDipoleSuperpara
+
+import numpy as np
+
+#################
+
+# Simulation parameters
+sim_params = {'DENS_PART': 0.3, 'BOND_K': "soft", 'HEIGHT': 6,
+              'N_FULL_BOX': 120*4, 'seed': 1,
+              'H': 1}
+
+# sim_inst params
+DENS_PART = sim_params['DENS_PART']
+MAE_LAYER_HEIGHT_parts = sim_params['HEIGHT'] # in part size units
+N_M_FULL_BOX = sim_params['N_FULL_BOX']
+
+SIGMA_PART = 1.
+SIZE_PART = SIGMA_PART*pow(2, 1/6)  # in sim_inst units
+print(f"SIZE_PART={SIZE_PART}")
+R_PART= SIZE_PART/2
+
+BONDS_MAX_LENGHT_A = 5.
+BOND_K_A = sim_params['BOND_K']
+valid_bond_limits = {'soft': (0.001, 0.01), 'hard': (0.01, 0.1)}
+BOND_LIMITS_A = valid_bond_limits.get(BOND_K_A)
+if BOND_LIMITS_A is None:
+   raise ValueError(f"Invalid bond type: {BOND_K_A}. Valid --K values -> {valid_bond_limits.keys()}")
+
+MAE_LAYER_HEIGHT = MAE_LAYER_HEIGHT_parts * SIZE_PART # in sim_inst units
+BOX_SIZE = np.cbrt( N_M_FULL_BOX * 4/3*np.pi / 0.3 ) * R_PART
+BOX_Z_MAX = 4 * BOX_SIZE
+
+N_PART = round(DENS_PART * BOX_SIZE**2 * MAE_LAYER_HEIGHT / ( 4/3 * np.pi * R_PART**3))
+
+assert MAE_LAYER_HEIGHT<=BOX_Z_MAX
+assert DENS_PART<=0.3
+
+box_l = [BOX_SIZE, BOX_SIZE, BOX_Z_MAX]
+box_E = [BOX_SIZE, BOX_SIZE, MAE_LAYER_HEIGHT]
+
+dens_A = N_PART * 4/3 * np.pi * R_PART**3 / np.prod(box_E)
+
+assert dens_A - DENS_PART < 0.001, f"DENS_{dens_A}"
+
+# INITIALIZE sim_inst
+sim_inst = Simulation(box_dim=box_l)
+sim_inst.sys.box_l=box_l
+sim_inst.seed = sim_params['seed']
+sim_inst.set_sys(timestep=0.001)
+
+config_pdp = PointDipolePermanent.config.specify(dipm=1., espresso_handle=sim_inst.sys)
+config_pds = PointDipoleSuperpara.config.specify(dipm=1., espresso_handle=sim_inst.sys)
+n_pdp = int(N_PART/2); n_pds = N_PART - n_pdp
+associated_objects = [PointDipolePermanent(config=config_pdp) for _ in range(n_pdp)] + [PointDipoleSuperpara(config=config_pds) for _ in range(n_pds)]
+assert len(associated_objects) == N_PART
+config_E = Elastomer.config.specify(box_E=box_E, box_E_shift=[0,0,0.5], n_parts=N_PART, associated_objects=associated_objects, bond_K_lims=BOND_LIMITS_A, size=SIZE_PART, sigma=SIGMA_PART, espresso_handle=sim_inst.sys, seed=sim_inst.seed)
+elastomer=[Elastomer(config=config_E) for _ in range(1)]
+sim_inst.store_objects(elastomer)
+sim_inst.set_objects(elastomer)
+elastomer= elastomer[0]
+
+sim_inst.set_steric(key=("pdp_real", "pds_real"))
+sim_inst.sys.integrator.run(0)
+# energy = sim_inst.sys.analysis.energy()
+# print(energy["total"])
+# print(energy["kinetic"])
+# print(energy["bonded"])
+# print(energy["non_bonded"])
+# print(energy["external_fields"])
+# print(sim_inst.part_types)
+# print(energy["non_bonded", 61, 61])
+# print(energy["non_bonded", 61, 62])
+# print(energy["non_bonded", 62, 62])
+# print(len(list(sim_inst.sys.part.select(type=sim_inst.part_types['real']))))
+
+
+
+# # must add non_bonded interactions before creating substrate
+# elastomer.create_substrate(geometry='part')
+
+# elastomer.mix_elastomer_stuff(test=True)
+
+# elastomer.cure_elastomer(test=True)
+
+
+
+# elastomer.relax_langevin(test=True)
+
+# #### Run the sample with external H ####
+
+# # Add thermostat
+# sim_inst.sys.thermostat.set_langevin(kT=1., gamma=1., seed=sim_inst.seed)
+
+# # Add magnetic dipole interactions - direct sum, non-preiodic in z
+# sim_inst.sys.periodicity = [True, True, False]
+# dds = espressomd.magnetostatics.DipolarDirectSumCpu(prefactor=1)
+# sim_inst.sys.magnetostatics.solver = dds
+# sim_inst.sys.integrator.run(0)
+
+# # Mark particles to magnetize. Careful to use python lists, and not espressomd particle slices
+# pds_to_magnetize = list(sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']))
+# parts_to_magnetize = [[pds_to_magnetize, config_pds['dipm']],]
+# sim_inst.sys.integrator.run(10)
+
+# # Gradually increasing dipole moments for permanent dipoles
+# if any(isinstance(obj, PointDipolePermanent) for obj in sim_inst.objects):
+#     sim_inst.sys.time_step = 0.001
+#     dipm_pdp= 0.
+#     dipm_incr = config_pdp['dipm'] / 10
+#     sim_inst.sys.part.select(type=sim_inst.part_types['pdp_real']).dipm = 1E-6 # Cannot start at 0
+#     sim_inst.sys.integrator.run(0, recalc_forces=True)
+#     for _ in range(10):
+#         dipm_pdp += dipm_incr
+#         sim_inst.sys.part.select(type=sim_inst.part_types['pdp_real']).dipm = dipm_pdp
+#         for step in range(1):
+#             sim_inst.sys.integrator.run(1, recalc_forces=True)
+#             for parts, dipm_pds in parts_to_magnetize:
+#                 sim_inst.magnetize(part_list=parts, dip_magnitude=dipm_pds, H_ext=np.asarray([0,0,1e-6]))
+
+#     assert (np.abs( sim_inst.sys.part.select(type=sim_inst.part_types['pdp_real']).dipm - config_pdp['dipm']) < 0.001  ).all()
+
+# STABILIZE MAE WITH MAGNETIC FIELD
+# sim_inst.sys.time = 0.
+
+# ext_B_z = sim_params['H']
+# H_ext = [0,0,ext_B_z]
+# sim_inst.set_H_ext(H=H_ext)
+
+# for step in range(2):
+#     sim_inst.sys.integrator.run(1, recalc_forces=True)
+#     for parts, dipm in parts_to_magnetize:
+#         sim_inst.magnetize(part_list=parts, dip_magnitude=dipm, H_ext=sim_inst.get_H_ext())

--- a/samples/mae-BoS.py
+++ b/samples/mae-BoS.py
@@ -1,9 +1,12 @@
 import espressomd
-import espressomd.magnetostatics
-import espressomd.checkpointing
+if espressomd.version.major()==5:
+    from espressomd.magnetostatics import DipolarDirectSum
+elif espressomd.version.major()==4:
+    from espressomd.magnetostatics import DipolarDirectSumCpu
+else:
+    raise ImportError(f"Unsupported ESPResSo version: {espressomd.version}. Please use version 4 or 5.")
 import logging
 logging.basicConfig(level=logging.INFO)
-from espressomd.io.writer import vtf
                   
 espressomd.assert_features(['WCA', 'ROTATION', 'DIPOLES', 'DP3M',
                             'VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE',
@@ -92,8 +95,10 @@ sim_inst.sys.thermostat.set_langevin(kT=1., gamma=1., seed=sim_inst.seed)
 
 # Add magnetic dipole interactions - direct sum, non-preiodic in z
 sim_inst.sys.periodicity = [True, True, False]
-dds = espressomd.magnetostatics.DipolarDirectSumCpu(prefactor=1)
-sim_inst.sys.magnetostatics.solver = dds
+if espressomd.version.major()==5:
+    sim_inst.init_magnetic_inter(DipolarDirectSum(prefactor=1))
+else:
+    sim_inst.init_magnetic_inter(DipolarDirectSumCpu(prefactor=1))
 sim_inst.sys.integrator.run(0)
 
 # Mark particles to magnetize. Careful to use python lists, and not espressomd particle slices

--- a/samples/mae-BoS.py
+++ b/samples/mae-BoS.py
@@ -1,4 +1,5 @@
 import espressomd
+import espressomd.version
 if espressomd.version.major()==5:
     from espressomd.magnetostatics import DipolarDirectSum
 elif espressomd.version.major()==4:
@@ -79,7 +80,8 @@ sim_inst.set_steric(key=("pdp_real", "pds_real"))
 sim_inst.sys.integrator.run(0)
 
 # must add non_bonded interactions before creating substrate
-elastomer.create_substrate(geometry='part')
+substrate_geometry = 'wall' if espressomd.version.major() == 4 else 'part'
+elastomer.create_substrate(geometry=substrate_geometry)
 energy = sim_inst.sys.analysis.energy()
 print("total",energy["total"])
 print("bonded",energy["bonded"])

--- a/samples/mag_filament.py
+++ b/samples/mag_filament.py
@@ -7,15 +7,15 @@ from espressomd.magnetostatics import DipolarDirectSumCpu
 from espressomd.io.writer import vtf
 
 sigma = 1.
-n_part_tot = 10
+n_fil = 10
 density=0.1
-box_dim = np.power((4*n_part_tot*np.pi*np.power(sigma/2, 3))/(3*density), 1/3)*np.ones(3)
+box_dim = [10,10,10]*np.ones(3)
 logging.info('box_dim: ', box_dim)
 sim_inst = Simulation(box_dim=box_dim)
 sim_inst.set_sys()
 bond_hndl=BondWrapper(espressomd.interactions.FeneBond(k=10, d_r_max=3*sigma, r_0=0))
 configuration=Filament.config.specify(sigma=sigma, size=2.26,n_parts=2, espresso_handle=sim_inst.sys,bond_handle=bond_hndl)
-filaments = [Filament(config=configuration) for x in range(5)]
+filaments = [Filament(config=configuration) for x in range(n_fil)]
 
 sim_inst.store_objects(filaments)
 sim_inst.set_objects(filaments)

--- a/test/test_box_partitioning.py
+++ b/test/test_box_partitioning.py
@@ -14,8 +14,8 @@ class PartitioningTest(BaseTestCase):
 
     def test_get_neighbours(self):
         control= {0: [2,], 1: [2,],2: [0, 1, 3, 4,], 3: [2, ], 4: [2,]}
-        sphere_centers_short, _,_=partition_cubic_volume(self.box_len,self.num_vol_side,self.sph_diam, flag='norand')
-        neigh=get_neighbours(sphere_centers_short,self.box_len,cuttoff=self.sph_diam)
+        sphere_centers_short, _,_=partition_cubic_volume(np.ones(3) * self.box_len,self.num_vol_side,self.sph_diam, flag='norand')
+        neigh=get_neighbours(sphere_centers_short,np.ones(3) * self.box_len,cuttoff=self.sph_diam)
         neigh_sets = {key: set(val) for key, val in neigh.items()}
         control_sets = {key: set(val) for key, val in control.items()}
         self.assertEqual(neigh_sets,control_sets,'the get_neighbour method failed to reproduce correct neighbour pairs for a single face of an fcc lattice')
@@ -23,11 +23,11 @@ class PartitioningTest(BaseTestCase):
     def test_get_neighbours_cross_lattice(self):
         
         control={0: [0, 2, 5, 6], 1: [1, 2, 5, 7], 2: [0, 1, 2, 3, 4, 5, 6, 7, 8], 3: [2, 3, 6, 8], 4: [2, 4, 7, 8]}
-        sphere_centers_long, _,_=partition_cubic_volume(self.box_len,self.num_vol_all,self.sph_diam,flag='norand')
+        sphere_centers_long, _,_=partition_cubic_volume(np.ones(3) * self.box_len,self.num_vol_all,self.sph_diam,flag='norand')
 
-        sphere_centers_short, _,_=partition_cubic_volume(self.box_len,self.num_vol_side,self.sph_diam,flag='norand')
+        sphere_centers_short, _,_=partition_cubic_volume(np.ones(3) * self.box_len,self.num_vol_side,self.sph_diam,flag='norand')
 
-        neigh=get_neighbours_cross_lattice(sphere_centers_short,sphere_centers_long,self.box_len,cuttoff=self.sph_diam)
+        neigh=get_neighbours_cross_lattice(sphere_centers_short,sphere_centers_long,np.ones(3) * self.box_len,cuttoff=self.sph_diam)
         self.assertEqual(neigh,control,'the get_neighbour method failed to reproduce correct neighbour pairs for a single face of an fcc lattice')  
 
     def test_get_neighbours_rectangular(self):

--- a/test/test_box_partitioning.py
+++ b/test/test_box_partitioning.py
@@ -1,19 +1,24 @@
+import numpy as np
+
 from pressomancy.simulation import partition_cubic_volume, get_neighbours, get_neighbours_cross_lattice
 from create_system import BaseTestCase
 
 class PartitioningTest(BaseTestCase):
-    box_len=2.5
+    box_len=np.array([2.5, 2.5, 2.5])
     num_vol_all=14
     num_vol_side=5
 
     sph_diam=1
     sph_rad=0.5*sph_diam
+    rect_box = np.array([10.0, 20.0, 30.0])
 
     def test_get_neighbours(self):
-        control= {0: [2,], 1: [2,],2: [0, 1, 3, 4, ], 3: [2, ], 4: [2,]}
+        control= {0: [2,], 1: [2,],2: [0, 1, 3, 4,], 3: [2, ], 4: [2,]}
         sphere_centers_short, _,_=partition_cubic_volume(self.box_len,self.num_vol_side,self.sph_diam, flag='norand')
         neigh=get_neighbours(sphere_centers_short,self.box_len,cuttoff=self.sph_diam)
-        self.assertEqual(neigh,control,'the get_neighbour method failed to reproduce correct neighbour pairs for a single face of an fcc lattice')
+        neigh_sets = {key: set(val) for key, val in neigh.items()}
+        control_sets = {key: set(val) for key, val in control.items()}
+        self.assertEqual(neigh_sets,control_sets,'the get_neighbour method failed to reproduce correct neighbour pairs for a single face of an fcc lattice')
 
     def test_get_neighbours_cross_lattice(self):
         
@@ -24,6 +29,97 @@ class PartitioningTest(BaseTestCase):
 
         neigh=get_neighbours_cross_lattice(sphere_centers_short,sphere_centers_long,self.box_len,cuttoff=self.sph_diam)
         self.assertEqual(neigh,control,'the get_neighbour method failed to reproduce correct neighbour pairs for a single face of an fcc lattice')  
+
+    def test_get_neighbours_rectangular(self):
+        box = self.rect_box
+        cut = 2.0
+        points = np.array(
+            [
+                # Across x-boundary (wrap), within cutoff.
+                [0.5, 10.0, 15.0],
+                [9.7, 10.0, 15.0],
+                # Central point should not be within cutoff of either.
+                [5.0, 10.0, 15.0],
+            ]
+        )
+        neigh = get_neighbours(points, box, cuttoff=cut)
+
+        self.assertIn(1, neigh[0])
+        self.assertIn(0, neigh[1])
+        self.assertNotIn(2, neigh[0])
+        self.assertNotIn(2, neigh[1])
+
+    def test_get_neighbours_cross_lattice_rectangular(self):
+        box = self.rect_box
+        cut = 2.0
+        lattice_a = np.array(
+            [
+                # Nearest neighbor only across x-boundary.
+                [0.5, 10.0, 15.0],
+                # Nearest neighbor only inside the box.
+                [5.0, 10.0, 15.0],
+            ]
+        )
+        lattice_b = np.array(
+            [
+                [9.7, 10.0, 15.0],
+                [5.9, 10.0, 15.0],
+                # Far in y; should be excluded.
+                [5.0, 18.5, 15.0],
+            ]
+        )
+        neigh = get_neighbours_cross_lattice(lattice_a, lattice_b, box, cuttoff=cut)
+
+        expected = {0: [0], 1: [1]}
+        self.assertEqual(neigh, expected)
+
+    def test_get_neighbours_multiple_rectangular(self):
+        box = self.rect_box
+        cut = 0.35
+        points = np.array(
+            [
+                # Point at origin corner.
+                [0.2, 0.2, 0.2],
+                # Within cutoff across x-boundary.
+                [9.9, 0.2, 0.2],
+                # Within cutoff across y-boundary.
+                [0.2, 19.9, 0.2],
+                # Within cutoff across z-boundary.
+                [0.2, 0.2, 29.9],
+                # Far center point.
+                [5.0, 10.0, 15.0],
+            ]
+        )
+        neigh = get_neighbours(points, box, cuttoff=cut)
+        expected = {0: [1, 2, 3], 1: [0], 2: [0], 3: [0]}
+        neigh_sets = {key: set(val) for key, val in neigh.items()}
+        expected_sets = {key: set(val) for key, val in expected.items()}
+        self.assertEqual(neigh_sets, expected_sets)
+
+    def test_get_neighbours_cross_lattice_multiple_rectangular(self):
+        box = self.rect_box
+        cut = 0.35
+        lattice_a = np.array(
+            [
+                # Should match two neighbors across x/y boundaries.
+                [0.2, 0.2, 0.2],
+                # Should match only the nearby internal point.
+                [5.0, 10.0, 15.0],
+            ]
+        )
+        lattice_b = np.array(
+            [
+                [9.9, 0.2, 0.2],
+                [0.2, 19.9, 0.2],
+                [5.1, 10.0, 15.0],
+                # Far away; should be excluded.
+                [8.0, 8.0, 8.0],
+            ]
+        )
+        neigh = get_neighbours_cross_lattice(lattice_a, lattice_b, box, cuttoff=cut)
+
+        expected = {0: [0, 1], 1: [2]}
+        self.assertEqual(neigh, expected)
         
 # control={0: [0, 1, 2, 3, 5, 6, 9],
         #      1: [ 0,  1,  2,  4,  5,  7, 10],

--- a/test/test_samples.py
+++ b/test/test_samples.py
@@ -35,5 +35,6 @@ class SampleScriptTest(BaseTestCase):
                         fp.flush()
             sim_inst.reinitialize_instance()
             sim_inst.sys.thermostat.turn_off()
+            sim_inst.sys.box_l = (100,100,100)
             self.assertEqual(len(sim_inst.objects), 0)
             self.assertEqual(len(sim_inst.sys.part), 0)

--- a/test/test_system.py
+++ b/test/test_system.py
@@ -3,7 +3,6 @@ import inspect
 import logging
 from create_system import sim_inst, BaseTestCase
 from pressomancy.helper_functions import MissingFeature
-import espressomd
 
 class SimulationTest(BaseTestCase):
     num_vol_all=14


### PR DESCRIPTION
This PR adds foundational support for rectangular simulation boxes across the placement and neighbor-finding utilities, and introduces an initial elastomer workflow needed to unblock follow-on elastomer work.

The core change is that box-handling logic that previously assumed a single cubic side length now accepts full (x, y, z) box dimensions. This updates volume partitioning, lattice generation, pair-distance calculations, and neighbor detection so they work correctly in non-cubic boxes while preserving the existing cubic behavior.

On top of that, this PR adds the first elastomer-oriented object support, including new Elastomer, PointDipolePermanent, and PointDipoleSuperpara. This is intended as a stopgap integration PR: it brings in the rectangular-box infrastructure and the minimum elastomer scaffolding needed to unblock a more focused elastomer PR that will refine that area further.