### PR TITLE
Adding elastomer support to pressomancy (supersedes last pull request #8)

### DIFF
--- a/doc/sphinx/source/first_simulation.rst
+++ b/doc/sphinx/source/first_simulation.rst
@@ -89,7 +89,7 @@ the simulation manager need to agree on.
 
 Particle creation begins when you call
 :meth:`~pressomancy.simulation.Simulation.set_objects`. The simulation first
-uses :func:`~pressomancy.helper_functions.partition_cubic_volume` to generate
+uses :func:`~pressomancy.helper_functions.partition_cuboid_volume` to generate
 candidate regions in the box. That helper uses an FCC lattice as a dense and
 regular scaffold for placement. For each chosen region, the simulation calls
 the object's ``build_function`` to obtain the local pattern appropriate for

--- a/doc/sphinx/source/io_and_analysis.rst
+++ b/doc/sphinx/source/io_and_analysis.rst
@@ -79,7 +79,16 @@ explicit about what each one assumes.
   previous HDF5 file should act as the source of positions, orientations, and
   selected properties for a newly constructed simulation.
 
-In day-to-day restart work, ``LOAD_NEW`` is usually the strongest option. The
+In day-to-day restart work, ``LOAD_NEW`` is usually the strongest option.
+
+New files also carry optional metadata that complements the particle and
+connectivity layout. The writer records H5MD-style root metadata under
+``/h5md`` together with pressomancy-specific metadata under
+``/parameters/pressomancy``. In practice, that metadata serves two roles.
+First, it stores lightweight provenance for the submission script and the
+pressomancy checkout that produced the file. Second, it stores the current
+``part_types`` map so that ``LOAD_NEW`` can restore symbolic particle-type
+bookkeeping directly when that information is available. The
 connectivity tables in the HDF5 file give pressomancy enough information to
 rebuild the flat particle view directly from saved object ownership, which is
 why it offers extra functionality compared with ``LOAD``.
@@ -171,7 +180,11 @@ by timestep, then by object ownership, then by a property predicate, without
 having to manually reconstruct index arrays outside the API.
 
 The object-context helpers are what make the selector especially useful for
-pressomancy-generated data. ``select_particles_by_object`` gives you the
+pressomancy-generated data. The selector also exposes the structural metadata
+written to the HDF5 file through ``data.metadata``. Group attributes are kept
+under ``_meta["attributes"]``, which makes file-level metadata such as
+``/h5md`` creator information or ``/parameters/pressomancy/part_types``
+accessible without introducing a second analysis API. ``select_particles_by_object`` gives you the
 particle subset belonging to one saved object instance, such as one
 :class:`~pressomancy.object_classes.filament_class.Filament` or one
 :class:`~pressomancy.object_classes.quadriplex_class.Quadriplex`.

--- a/doc/sphinx/source/simulation_and_objects.rst
+++ b/doc/sphinx/source/simulation_and_objects.rst
@@ -38,7 +38,7 @@ leaves.
 
 The placement pipeline follows that logic directly.
 :meth:`~pressomancy.simulation.Simulation.set_objects` calls
-:func:`~pressomancy.helper_functions.partition_cubic_volume` to generate
+:func:`~pressomancy.helper_functions.partition_cuboid_volume` to generate
 candidate regions in the box. The helper starts from an FCC lattice because it
 provides a dense and regular set of trial centers. For each accepted center,
 the simulation calls the object's ``build_function`` to ask what local point

--- a/pressomancy/analysis/data_analysis.py
+++ b/pressomancy/analysis/data_analysis.py
@@ -59,6 +59,7 @@ class H5DataSelector:
             Returns a dict with keys for each member, and a '_meta' key containing:
               - type: 'Group'
               - members: list of member names
+              - attributes: dict of group attributes
 
         For datasets:
             Returns a dict containing:
@@ -77,7 +78,8 @@ class H5DataSelector:
         if isinstance(obj, h5py.Group):
             tree['_meta'] = {
                 'type': 'Group',
-                'members': list(obj.keys())
+                'members': list(obj.keys()),
+                'attributes': {attr: obj.attrs[attr] for attr in obj.attrs}
             }
             for key, item in obj.items():
                 tree[key] = self._build_h5_tree(item)

--- a/pressomancy/helper_functions.py
+++ b/pressomancy/helper_functions.py
@@ -6,6 +6,8 @@ import logging
 import espressomd.version
 import sys as sysos
 import warnings
+import subprocess
+from pathlib import Path
 
 class MissingFeature(Exception):
     pass
@@ -1454,3 +1456,71 @@ class BondWrapper:
         Returns the raw object being wrapped.
         """
         return self._bond_handle
+
+def get_repo_context(path):
+    """Return the enclosing git repository root and a provenance version string.
+
+    The version string stores the current branch and commit hash and appends ``-dirty`` when
+    the repository has uncommitted changes. If the path is not inside a git
+    repository, or if the git query fails, the version falls back to ``unknown``.
+    """
+    path = Path(path).resolve()
+    search_root = path if path.is_dir() else path.parent
+    repo_root = None
+    for candidate in (search_root, *search_root.parents):
+        if (candidate / ".git").exists():
+            repo_root = candidate
+            break
+    if repo_root is None:
+        return None, "unknown"
+    try:
+        branch = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        commit = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--short", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        dirty = subprocess.run(
+            ["git", "-C", str(repo_root), "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except Exception:
+        return repo_root, "unknown"
+    suffix = "-dirty" if dirty else ""
+    return repo_root, f"{branch}@{commit}{suffix}"
+
+def get_submission_creator_info():
+    """Return H5MD creator metadata for the active submission script.
+
+    The creator name is reported as ``repo_name/repo_relative_path`` when the
+    script belongs to a git repository, and as ``unknown/<script_name>``
+    otherwise. The accompanying version string follows :func:`get_repo_context`.
+    """
+    package_root = Path(__file__).resolve().parent
+    current_file = Path(__file__).resolve()
+    frame = inspect.currentframe()
+    script_path = None
+    while frame is not None:
+        filename = frame.f_code.co_filename
+        if filename:
+            candidate = Path(filename).resolve()
+            if candidate != current_file and package_root not in candidate.parents:
+                script_path = candidate
+                break
+        frame = frame.f_back
+
+    if script_path is None:
+        return "unknown/unknown", "unknown"
+    repo_root, version = get_repo_context(script_path)
+    if repo_root is None:
+        return f"unknown/{script_path.name}", "unknown"
+    relpath = script_path.relative_to(repo_root).as_posix()
+    return f"{repo_root.name}/{relpath}", version

--- a/pressomancy/helper_functions.py
+++ b/pressomancy/helper_functions.py
@@ -825,16 +825,16 @@ def make_centered_rand_orient_point_array(center=np.array([0,0,0]), sphere_radiu
     orientation_vectors = np.broadcast_to(orientation_vector, points.shape).copy()
     return orientation_vectors,points
 
-def partition_cubic_volume(box_lengths, num_spheres, sphere_diameter, routine_per_volume=RoutineWithArgs(), flag='rand'):
+def partition_cuboid_volume(box_lengths, num_spheres, sphere_diameter, routine_per_volume=RoutineWithArgs(), flag='rand'):
     """
-    Partitions a cubic volume into spherical regions and generates points within them.
-    This function creates a face-centered cubic (FCC) lattice of spheres within a cubic volume and optionally
+    Partitions a cuboid volume into spherical regions and generates points within them.
+    This function creates a face-centered cubic (FCC) lattice of spheres within a cuboid volume and optionally
     generates points within each sphere according to a specified routine.
     
     Parameters
     ----------
     box_lengths : array-like of shape (3,)
-        The side lengths of the cubic volume.
+        The side lengths of the cuboid volume.
     num_spheres : int
         The desired number of spherical regions to create.
     sphere_diameter : float
@@ -1419,11 +1419,6 @@ def normalize_vectors(vectors, axis=-1):
         return array_of_vectors / np.expand_dims(norms_array, axis)
     else: # if only one vector return an array of shape (dims,)Z
         return array_of_vectors / np.linalg.norm(array_of_vectors)
-    
-def str_to_bool(string):
-    if string not in ['True', 'true', '1', 'False', 'false', '0']:
-        raise TypeError(f" '{string}' is not convertible to bool")
-    return string in ['True', 'true', '1']
 
 class BondWrapper:
     def __init__(self, bond_handle):

--- a/pressomancy/object_classes/elastomer.py
+++ b/pressomancy/object_classes/elastomer.py
@@ -144,7 +144,7 @@ class Elastomer(metaclass=Simulation_Object):
 
         return orientations, points
     
-    def mix_elastomer_stuff(self, iter_multiplier=1, test=False):
+    def mix_elastomer_stuff(self, iter_multiplier=1, test=False, time_step=0.001):
         if isinstance(self, list):
             raise ValueError("Must be used on Elastomer object type")
 
@@ -153,11 +153,10 @@ class Elastomer(metaclass=Simulation_Object):
 
         if test:
             n_iter_1 = 100
-            self.sys.time_step = 0.001
         else:
             n_iter_1 = int(1000000 * iter_multiplier)
-            self.sys.time_step = 0.001
-
+        
+        self.sys.time_step = time_step
 
         if self.substrate is None:
             raise ValueError("Substrate must be created before mix_elastomer_stuff().")

--- a/pressomancy/object_classes/elastomer.py
+++ b/pressomancy/object_classes/elastomer.py
@@ -2,9 +2,7 @@ import espressomd
 import numpy as np
 from collections import defaultdict
 from pressomancy.object_classes.object_class import Simulation_Object, ObjectConfigParams
-from pressomancy.object_classes.point_dipole import PointDipolePermanent
-from pressomancy.helper_functions import RoutineWithArgs, PartDictSafe, SinglePairDict, BondWrapper, add_box_constraints_func, remove_box_constraints_func, check_free_cuboid, fcc_lattice, generate_random_unit_vectors, normalize_vectors, get_neighbours, str_to_bool
-import logging
+from pressomancy.helper_functions import RoutineWithArgs, PartDictSafe, SinglePairDict, add_box_constraints_func, remove_box_constraints_func, check_free_cuboid, fcc_lattice, generate_random_unit_vectors, get_neighbours
 import warnings
 import os
 import sys as sysos
@@ -19,14 +17,18 @@ class Elastomer(metaclass=Simulation_Object):
     part_types = PartDictSafe({'real':1, 'substrate': 98})
     config = ObjectConfigParams(
         box_E= None,
+        layer_height= None,
         n_parts= None,
         bond_type= "HarmonicBond",
         bond_K_dist= "normal",
         bond_K_lims= (0.01,0.1),
         bond_cutoff= 5.,
         max_bonds= 6,
-        seed= int.from_bytes(os.urandom(2), sysos.byteorder)
+        seed= int.from_bytes(os.urandom(2), sysos.byteorder),
+        sigma= None
         )
+    
+    _substrate_size = 1.
 
     def __init__(self, config: ObjectConfigParams):
         '''
@@ -34,11 +36,24 @@ class Elastomer(metaclass=Simulation_Object):
         '''
         self.sys=config['espresso_handle']
         if config['box_E'] is None:
-            config['box_E'] = self.sys.box_l
-        config['box_E'] = np.asarray(config['box_E'])
+            config['box_E'] = np.array(self.sys.box_l, copy=True)
+            if config['layer_height'] is None:
+                config['box_E'][2] = self.sys.box_l[2] / 4
+                config['layer_height'] = config['box_E'][2] - self._substrate_size
+            else:
+                config['box_E'][2] = self._substrate_size + config['layer_height']
+                assert config['box_E'][2] <= self.sys.box_l[2]
+        else:
+            if config['layer_height'] is None:
+                config['layer_height'] = config['box_E'][2] - self._substrate_size
+            elif config['box_E'][2] != self.sys.box_l[2]:
+                raise ValueError("box_E and layer_height are not compatible. Ensure that box_E[2] == layer_height.\nAlternatively, use only on of the parameters and hae the other be automatically chosen.")
+        assert config['layer_height'] == config['box_E'][2] - self._substrate_size
+        if config['sigma'] is None:
+            config['sigma'] = config['size'] * 0.89089872 # size / 2^(1/6)
         if config['n_parts'] is None:
-            config['n_parts']= int( 0.2 * (np.prod(config['box_E']) /  4.18879) )
-            warnings.warn('monomer size assumed to be 1. and inferred number of particles from volume of Elastomer (to get 0.3 volume fraction)')
+            config['n_parts']= int( 0.3 * (config['box_E'][0] * config['box_E'][1] * config['layer_height']) /  ( 4.1887902 * (config['size']/2)**3 ) ) # 0.3 * V_box / V_sphere
+            warnings.warn('Inferred number of particles from volume of Elastomer (to get 0.3 volume fraction)')
         self.params=config
         self.associated_objects=self.params['associated_objects']
         if self.associated_objects is not None:
@@ -63,9 +78,10 @@ class Elastomer(metaclass=Simulation_Object):
 
         '''
         pos=np.atleast_2d(pos)
+        pos_z=pos[:,2]
+        assert np.all((pos_z >= self._substrate_size + self.params['size']/2) & (pos_z <= self.params['box_E'][2] - self.params['size'] / 2)), f"particle positions are outisde of elastomer space.\n\t min({pos_z.min()}) max({pos_z.max()}). should be min({self._substrate_size+self.params['size']/2}) max({self.params['box_E'][2]-self.params['size'] / 2})"
         assert check_free_cuboid(self.sys, self.params['box_E']), "Elastomer must be build on empty space. Adjust box_E or remove non-elastomer particles to make space."
-        assert len(
-            pos) == self.params['n_parts'], 'there is a missmatch between the pos lenth and Elastomer n_parts'
+        assert len(pos) == self.params['n_parts'], 'there is a missmatch between the pos lenth and Elastomer n_parts'
         if self.associated_objects is None:
             dipm= 1.
             logic = (self.add_particle(type_name='real',pos=pp, dip=(dipm * oo), rotation=(True, True, True)) for pp, oo in zip(pos, ori))
@@ -78,16 +94,23 @@ class Elastomer(metaclass=Simulation_Object):
                         for obj_el, pos_el, ori_el in zip(self.associated_objects, pos, ori))
         for part in logic:
             pass
+
+        self.create_substrate()
         
         return self
     
     def build_Elastomer(self, center=None, sphere_radius=1., num_monomers=1, spacing=None, flag='rand'):
-        box_lengths = np.asarray(self.params['box_E'])
-        z_offset = 0.5 + self.params['size']
+        box_lengths = np.asarray(self.sys.box_l)
+        box_lengths_tmp = np.asarray(self.params['box_E'])
+        assert (box_lengths_tmp <= box_lengths).all()
+        box_lengths = box_lengths_tmp
+
+        z_offset = self._substrate_size + self.params['size'] / 2
         box_lengths_eff = box_lengths.copy()
-        box_lengths_eff[2] -= z_offset
+        box_lengths_eff[2] = self.params['layer_height'] - self.params['size'] / 2 # layer height minus the shpere radius, to take into account for pbc volume in fcc funciton
         if box_lengths_eff[2] <= 0:
             raise ValueError("box_E[2] is too small to fit elastomer above substrate clearance.")
+
         scaling = 1.0
         
         # Adjust scaling until we have enough sphere centers
@@ -98,23 +121,23 @@ class Elastomer(metaclass=Simulation_Object):
                 break
             scaling -= 0.1
 
-        # Center point distribution in box (x/y) and enforce bottom z clearance.
-        min_centers = np.min(sphere_centers, axis=0)
-        max_centers = np.max(sphere_centers, axis=0)
-        sphere_centers += box_lengths_eff / 2 - (min_centers + max_centers) / 2
-        min_centers = np.min(sphere_centers, axis=0)
-        max_centers = np.max(sphere_centers, axis=0)
-        z_shift = z_offset - min_centers[2]
-        sphere_centers[:, 2] += z_shift
-        if np.max(sphere_centers[:, 2]) > box_lengths[2]:
-            warnings.warn('Elastomer lattice exceeds box_E after substrate clearance shift; increase box_E[2] or reduce n_parts.')
-
         # Randomly shuffle the available centers and select the required number of centers
         take_index = np.arange(len(sphere_centers))
         if flag=='rand':
             np.random.shuffle(take_index)
         take_index = take_index[:num_monomers]
         sphere_centers=sphere_centers[take_index]
+
+        # Center point distribution in box (x/y) and enforce bottom z clearance.
+        min_centers = np.min(sphere_centers, axis=0)
+        max_centers = np.max(sphere_centers, axis=0)
+        sphere_centers += box_lengths / 2 - (min_centers + max_centers) / 2
+        min_centers = np.min(sphere_centers, axis=0)
+        max_centers = np.max(sphere_centers, axis=0)
+        z_shift = z_offset - min_centers[2]
+        sphere_centers[:, 2] += z_shift
+        if np.max(sphere_centers[:, 2]) > box_lengths[2]:
+            warnings.warn('Elastomer lattice exceeds box_E after substrate clearance shift. This should not happen. Contact customer services.')
 
         points=sphere_centers
         orientations=generate_random_unit_vectors(len(sphere_centers))
@@ -130,30 +153,27 @@ class Elastomer(metaclass=Simulation_Object):
 
         if test:
             n_iter_1 = 100
-            self.sys.time_step = 0.0001
+            self.sys.time_step = 0.001
         else:
-            n_iter_1 = int(2000000 * iter_multiplier)
-            timestep_iter_1 = 0.0001
+            n_iter_1 = int(1000000 * iter_multiplier)
+            self.sys.time_step = 0.001
 
 
         if self.substrate is None:
             raise ValueError("Substrate must be created before mix_elastomer_stuff().")
 
-        # Add temporary walls (top and sides only).
+        # Add temporary wall (top and bottom only).
         types_M = tuple(typ for key, typ in self.part_types.items() if "real" in key)
         add_box_constraints_func(
-            sides=['top', 'left', 'right', 'back', 'front'],
+            sides=['top', 'bottom'],
             top=self.params['box_E'][2],
-            left=0,
-            right=self.params['box_E'][1],
-            back=0,
-            front=self.params['box_E'][0],
+            bottom=self._substrate_size,
             inter='wca',
             types_=types_M,
             sys=self.sys,
         )
 
-        self.sys.thermostat.set_langevin(kT=1, gamma=1, seed=self.params['seed'])
+        self.sys.thermostat.set_langevin(kT=1e-3, gamma=10, seed=self.params['seed'])
         self.sys.integrator.run(n_iter_1)
 
         # Remove temporary box particles
@@ -161,10 +181,16 @@ class Elastomer(metaclass=Simulation_Object):
 
         self.sys.thermostat.turn_off()
         self.sys.time_step = old_time_step
-        
-    def cure_elastomer(self, test=False, test_bad=False):
+    
+    def cure_elastomer(self, fold_coord=True, test_bad=False):
         if isinstance(self, list):
             raise ValueError("Must be used on Elastomer object type")
+
+        if fold_coord:
+            part_list= [part for typ_ in self.part_types for part in self.type_part_dict[typ_]]
+            for part in part_list:
+                pos_folded = part.pos_folded
+                part.pos = pos_folded
 
         if self.substrate is not None:
             # Stuck the bottom layer particles to the z=R_M plane
@@ -181,17 +207,15 @@ class Elastomer(metaclass=Simulation_Object):
                     for key, handles in obj.type_part_dict.items():
                         if isinstance(key, str) and "real" in key:
                             real_handles.extend(handles)
-            z_subs_tmp = 0.5
             if self.associated_objects is None:
-                z_tmp = z_subs_tmp + self.params['size']
+                z_tmp = self._substrate_size + self.params['size'] / 2
                 for hndl in self.type_part_dict['real']:
                     if hndl.pos[2] < (z_tmp + self.params['size'] / 4): # chose at which heights to capture Ms
-                        hndl.pos = [hndl.pos[0], hndl.pos[1], z_tmp]
                         hndl.fix = [False, False, True]                
                         n_pinned += 1
             else:
                 for obj in self.associated_objects:
-                    z_tmp = z_subs_tmp + obj.params['size']
+                    z_tmp = self._substrate_size + obj.params['size'] / 2
                     for key, typ in obj.part_types.items():
                         if "real" in key:
                             hndls = obj.type_part_dict[key]
@@ -200,7 +224,8 @@ class Elastomer(metaclass=Simulation_Object):
                                     # hndl.pos = [hndl.pos[0], hndl.pos[1], z_tmp]
                                     hndl.fix = [False, False, True]
                                     n_pinned += 1
-            # Bond particles
+
+        # Bond particles
         r_catch = self.params['bond_cutoff']
         max_bonds = self.params['max_bonds']
         bond_k = self.params['bond_K_lims']
@@ -210,7 +235,6 @@ class Elastomer(metaclass=Simulation_Object):
 
         if self.params['bond_type'] == "HarmonicBond":
             _, n_bonds_dict = self.random_harmonic_bonds(r_catch, bond_k, max_bonds, r_cut=-1, dist=dist, std_scaling=6)
-            logging.info("Added most bonds")
             lonely_M = []
             for id, n_bonds in n_bonds_dict.items():
                 if n_bonds == 0:
@@ -218,53 +242,6 @@ class Elastomer(metaclass=Simulation_Object):
             if lonely_M:
                 self.bond_to_neighbors(parts=self.sys.part.by_ids(lonely_M), n_nghb=n_bonds_if_0, bond_k=bond_k, r_cut=-1, r_catch=r_catch_if_0, dist=dist, std_scaling=6)
 
-    def relax_langevin(self, iter_multiplier=1, kT=1E-3, gamma=10, time_step=0.001, test=False):
-        if isinstance(self, list):
-            raise ValueError("Must be used on Elastomer object type")
-
-        # add iniziatilation process, to get a nice random distribution before bonding
-        if test:
-            n_iter = 0
-        else:
-            n_iter = int(200000 * iter_multiplier)
-
-        old_time_step= float(self.sys.time_step)
-        self.sys.time_step = time_step
-
-        self.sys.thermostat.set_langevin(kT=kT, gamma=gamma, seed=self.params['seed'])
-        self.sys.integrator.run(n_iter)
-        self.sys.time_step = old_time_step
-        self.sys.thermostat.turn_off()
-
-    def add_anchors(self,type_keys='all'): #TO BE DONE FOR ROTATION CONSTRAINTS
-        '''
-        Adds virtual particles at top and bottom of a particle with size sigma, as given by their director (aligned with the dipole moments for magnetic particles).
-        Logic firstly adds front anchors and then back anchors, so there is a consistent logic to track ids. Indices of particles added here are stored in self.fronts_indices/self.backs_indices attributes respectively.
-
-        :None:
-
-        '''
-        if type_keys == 'all':
-            type_keys = tuple(typ for key, typ in self.part_types.items() if "real" in key)
-        if self.associated_objects is not None:
-            raise NotImplementedError('add_anchors is still WIP for generic objects')
-        else:
-            self.fronts_indices=[]
-            self.backs_indices=[]
-
-            handles = self.type_part_dict['real']
-
-            logic_front = ((self.add_particle(type_name='virt', pos=part.pos + 0.5 * self.params['size'] * part.director, rotation=(False, False, False)), part) for part in handles)
-            logic_back  = ((self.add_particle(type_name='virt', pos=part.pos - 0.5 * self.params['size'] * part.director, rotation=(False, False, False)), part) for part in handles)
-
-            for part_front, part in logic_front:
-                part_front.vs_auto_relate_to(part)
-                self.fronts_indices.append(part_front.id)
-
-            for part_back, part in logic_back:
-                part_back.vs_auto_relate_to(part)
-                self.backs_indices.append(part_back.id)
-            logging.info(f'anchors added for Elastomer particles: {self.who_am_i}')
 
     def random_harmonic_bonds(self, r_catch, bond_k=(0.001, 0.01), max_bonds=None, r_cut=-1, dist="normal", std_scaling=6):
         """
@@ -312,10 +289,9 @@ class Elastomer(metaclass=Simulation_Object):
         if max_bonds is None:
             max_bonds = len(particles)
 
-        box_size= self.sys.box_l[0]
         box_lengths = self.sys.box_l
         if self.sys.periodicity[2]:
-            assert all(ele == box_size for ele in self.sys.box_l[1:]), "method assumes cubic box for system PBC"
+            assert all(ele == box_lengths[0] for ele in box_lengths[1:]), "method assumes cubic box for system PBC"
 
         if isinstance(bond_k, (float, int)):
             bond_k = [bond_k, bond_k]
@@ -394,10 +370,9 @@ class Elastomer(metaclass=Simulation_Object):
             old_periodicity = np.copy(self.sys.periodicity)
             self.sys.periodicity = [True, True, False]
 
-        box_size= self.sys.box_l[0]
         box_lengths = self.sys.box_l
         if self.sys.periodicity[2]:
-            assert all(ele == box_size for ele in self.sys.box_l[1:]), "method assumes cubic box for system PBC"
+            assert all(ele == box_lengths[0] for ele in box_lengths[1:]), "method assumes cubic box for system PBC"
 
         if isinstance(bond_k, (float, int)):
             bond_k = [bond_k, bond_k]
@@ -406,7 +381,7 @@ class Elastomer(metaclass=Simulation_Object):
                ), "method assumes bond_k to be either a number, or an interval represented by a tuple of the form (min, max)"
         
         if r_catch is None:
-            r_catch = box_size/2
+            r_catch = (box_lengths[2] - self._substrate_size) / 2
         assert r_cut > r_catch or r_cut == -1, "r_cut must be larger than any bond lenght. (default -1)"
         
         if dist in ("normal", "norm", "gaussian", "gauss"):
@@ -423,6 +398,7 @@ class Elastomer(metaclass=Simulation_Object):
         neighbours_dict = defaultdict(list)
         for idx, neigh in neighbours_raw.items():
             neighbours_dict[id_map[idx]] = [id_map[j] for j in neigh]
+            
         for id1 in parts.id:
             particle = self.sys.part.by_id(id1)
             n_count = 0
@@ -472,12 +448,13 @@ class Elastomer(metaclass=Simulation_Object):
             warnings.warn("Substrate not yet set. Will ignore this call.")
 
     def create_substrate_part(self):
+        substrate_radius = self._substrate_size / 2.
         n_substrate_x = int(np.ceil(self.params['box_E'][0]))
         n_substrate_y = int(np.ceil(self.params['box_E'][1]))
         n_substrate= n_substrate_x * n_substrate_y
-        pos_x, pos_y = np.meshgrid( np.linspace(0.5, self.params['box_E'][0]-0.5, n_substrate_x),
-                                    np.linspace(0.5, self.params['box_E'][1]-0.5, n_substrate_y) )
-        pos = np.column_stack((pos_x.ravel(), pos_y.ravel(), np.zeros(n_substrate) + 0.5))
+        pos_x, pos_y = np.meshgrid( np.linspace(substrate_radius, self.params['box_E'][0]-substrate_radius, n_substrate_x),
+                                    np.linspace(substrate_radius, self.params['box_E'][1]-substrate_radius, n_substrate_y) )
+        pos = np.column_stack((pos_x.ravel(), pos_y.ravel(), np.zeros(n_substrate) + substrate_radius))
 
         substrate_list= []
         for i in range(n_substrate):
@@ -485,16 +462,16 @@ class Elastomer(metaclass=Simulation_Object):
             substrate_list.append(part_hndl)
         self.substrate = substrate_list
 
+        substrate_sigma_half = substrate_radius * 0.89089871814 # radius / 2^(1/6)
         for key, typ in self.part_types.items():
             if "real" in key:
-                sigma = self.params['sigma']
-                if sigma < 0.001:
-                    raise ValueError(f"Interaction of type {typ} with wall is 0, has these particles have no interaction defined. If you would like to have no interactions between particles, but only with wall, then hange this function or do it with normal espresso constraints.")
-                self.sys.non_bonded_inter[self.part_types['substrate'], typ].wca.set_params(epsilon=10, sigma=sigma)
+                sigma = self.params['size'] * 0.445449359 + substrate_sigma_half # size/2 /2^(1/6) + substrate_sigma_half
+                self.sys.non_bonded_inter[self.part_types['substrate'], typ].wca.set_params(epsilon=1e6, sigma=sigma)
         
     def remove_substrate_part(self):
         for part in self.substrate:
             part.remove()
+            self.type_part_dict['substrate'].remove(part)
         self.substrate = None
 
         for key, typ in self.part_types.items():
@@ -503,41 +480,9 @@ class Elastomer(metaclass=Simulation_Object):
 
     def create_substrate_wall(self):
         types_M = tuple(typ for key, typ in self.part_types.items() if "real" in key)
-        wall_constraints = add_box_constraints_func(bottom=0, wall_type=self.part_types['substrate'], inter='wca', types_=types_M, sys=self.sys)
+        wall_constraints = add_box_constraints_func(bottom=self._substrate_size, wall_type=self.part_types['substrate'], inter='wca', types_=types_M, sys=self.sys)
         self.substrate = wall_constraints[0]
         
     def remove_substrate_wall(self):
         remove_box_constraints_func(wall_type=self.part_types['substrate'], sys=self.sys)
         self.substrate = None
-        
-def random_like_nested_3d_vectors(item, rng=None):
-    """
-    Recursively generate random 3D unit vectors,
-    matching the shape of nested lists, tuples, or arrays.
-    - Lists/tuples of len==3 with all numbers => treated as vector and replaced by a random unit vector.
-    - NumPy arrays with last dimension == 3 => generate array of random unit vectors with same shape.
-    - Otherwise recurse.
-    Raises error if a scalar or other unsupported leaf is found.
-    """
-    if rng is None:
-        rng = np.random.default_rng()
-    
-    if isinstance(item, (list, tuple)):
-        # Check if it is a 3D vector (leaf)
-        if len(item) == 3 and all(isinstance(x, (float, int)) for x in item):
-            return generate_random_unit_vectors(1).flatten().tolist()
-        else:
-            return [random_like_nested_3d_vectors(sub, rng) for sub in item]
-    
-    elif isinstance(item, np.ndarray):
-        if item.shape[-1] != 3:
-            raise ValueError(f"Expected last dimension to be 3 for 3D vectors, got shape {item.shape}")
-        
-        n_vectors = np.prod(item.shape[:-1])
-        vectors = generate_random_unit_vectors(n_vectors)
-        vectors = vectors.reshape(item.shape)
-        # Just to be sure normalize (your function is safe)
-        return normalize_vectors(vectors, axis=-1)
-
-    else:
-        raise ValueError(f"Expected last dimension to be 3 for 3D vectors, got {item}")

--- a/pressomancy/object_classes/elastomer.py
+++ b/pressomancy/object_classes/elastomer.py
@@ -457,7 +457,10 @@ class Elastomer(metaclass=Simulation_Object):
 
         substrate_list= []
         for i in range(n_substrate):
-            part_hndl = self.add_particle(type_name="substrate", pos=pos[i], type=self.part_types['substrate'], virtual=True, fix=[True,True,True])
+            if espressomd.version.major() == 5:
+                part_hndl = self.add_particle(type_name="substrate", pos=pos[i], type=self.part_types['substrate'], virtual=True, fix=[True,True,True])
+            elif espressomd.version.major() == 4:
+                part_hndl = self.add_particle(type_name="substrate", pos=pos[i], type=self.part_types['substrate'], fix=[True,True,True])
             substrate_list.append(part_hndl)
         self.substrate = substrate_list
 

--- a/pressomancy/object_classes/elastomer.py
+++ b/pressomancy/object_classes/elastomer.py
@@ -288,7 +288,7 @@ class Elastomer(metaclass=Simulation_Object):
         if max_bonds is None:
             max_bonds = len(particles)
 
-        box_lengths = self.sys.box_l
+        box_lengths = self.sys.box_l + 1e6 * ~np.array(self.sys.periodicity)
         if self.sys.periodicity[2]:
             assert all(ele == box_lengths[0] for ele in box_lengths[1:]), "method assumes cubic box for system PBC"
 
@@ -369,7 +369,7 @@ class Elastomer(metaclass=Simulation_Object):
             old_periodicity = np.copy(self.sys.periodicity)
             self.sys.periodicity = [True, True, False]
 
-        box_lengths = self.sys.box_l
+        box_lengths = self.sys.box_l + 1e6 * ~np.array(self.sys.periodicity)
         if self.sys.periodicity[2]:
             assert all(ele == box_lengths[0] for ele in box_lengths[1:]), "method assumes cubic box for system PBC"
 
@@ -380,7 +380,7 @@ class Elastomer(metaclass=Simulation_Object):
                ), "method assumes bond_k to be either a number, or an interval represented by a tuple of the form (min, max)"
         
         if r_catch is None:
-            r_catch = (box_lengths[2] - self._substrate_size) / 2
+            r_catch = (self.sys.box_l[2] - self._substrate_size) / 2
         assert r_cut > r_catch or r_cut == -1, "r_cut must be larger than any bond lenght. (default -1)"
         
         if dist in ("normal", "norm", "gaussian", "gauss"):

--- a/pressomancy/object_classes/point_dipole.py
+++ b/pressomancy/object_classes/point_dipole.py
@@ -1,7 +1,9 @@
 from pressomancy.object_classes.object_class import Simulation_Object, ObjectConfigParams 
 from pressomancy.helper_functions import PartDictSafe, SinglePairDict
 
-import espressomd.propagation
+import espressomd
+if espressomd.version.major() == 5:
+    import espressomd.propagation
 
 class PointDipolePermanent(metaclass=Simulation_Object):
     '''
@@ -40,7 +42,7 @@ class PointDipolePermanent(metaclass=Simulation_Object):
         hndl = self.add_particle(type_name='pdp_real', pos=pos, rotation=[True, True, True], dip=(dipm * ori))
 
         return self
-    
+
 class PointDipoleSuperpara(metaclass=Simulation_Object):
     '''
     Class that contains superparamagnetic point dipole particles relevant paramaters and methods. At construction one must pass an espresso handle because the class manages parameters that are both internal and external to espresso. It is assumed that in any simulation instanse there will be only one type of a PointDipoleSuperpara. Therefore many relevant parameters are class specific, not instance specific.
@@ -53,9 +55,9 @@ class PointDipoleSuperpara(metaclass=Simulation_Object):
     simulation_type= SinglePairDict('point_dipole_superpara', 4)
     part_types = PartDictSafe({'pds_real': 62, 'pds_virt': 666})
     config = ObjectConfigParams(
-         dipm=1.,
-         Xi_0=0.1,
-         mag_func=0
+        dipm=1.,
+        Xi_0=0.1,
+        mag_func=0
     )
 
     def __init__(self, config: ObjectConfigParams):
@@ -90,4 +92,3 @@ class PointDipoleSuperpara(metaclass=Simulation_Object):
         particl_virt.mag_susc_0 = self.params["Xi_0"]
 
         return self
-    

--- a/pressomancy/object_classes/point_dipole.py
+++ b/pressomancy/object_classes/point_dipole.py
@@ -1,6 +1,8 @@
 from pressomancy.object_classes.object_class import Simulation_Object, ObjectConfigParams 
 from pressomancy.helper_functions import PartDictSafe, SinglePairDict
 
+import espressomd.propagation
+
 class PointDipolePermanent(metaclass=Simulation_Object):
     '''
     Class that contains permanent magnetic point dipole particles relevant paramaters and methods. At construction one must pass an espresso handle because the class manages parameters that are both internal and external to espresso. It is assumed that in any simulation instanse there will be only one type of a PointDipolePermanent. Therefore many relevant parameters are class specific, not instance specific.
@@ -37,9 +39,6 @@ class PointDipolePermanent(metaclass=Simulation_Object):
         dipm= self.params['dipm']
         hndl = self.add_particle(type_name='pdp_real', pos=pos, rotation=[True, True, True], dip=(dipm * ori))
 
-        # Very Important Particle. To use to bond, calculate distances, and other Very Important Things. Usually at the center of mass, and usually a real particle
-        self.vip = hndl
-
         return self
     
 class PointDipoleSuperpara(metaclass=Simulation_Object):
@@ -49,12 +48,14 @@ class PointDipoleSuperpara(metaclass=Simulation_Object):
     Requires to run a magnetization function every step. Eg. system.magnetize()
     '''
 
-    required_features=['DIPOLES', 'DIPOLE_FIELD_TRACKING']	
+    required_features=['DIPOLES', 'DIPOLE_FIELD_TRACKING', 'MAGNETIZE']	
     numInstances = 0
     simulation_type= SinglePairDict('point_dipole_superpara', 4)
     part_types = PartDictSafe({'pds_real': 62, 'pds_virt': 666})
     config = ObjectConfigParams(
-         dipm=1.
+         dipm=1.,
+         Xi_0=0.1,
+         mag_func=0
     )
 
     def __init__(self, config: ObjectConfigParams):
@@ -79,11 +80,14 @@ class PointDipoleSuperpara(metaclass=Simulation_Object):
         '''
         particl_real=self.add_particle(type_name='pds_real', pos=pos, rotation=[True, True, True], director=ori)
         
-        particl_virt=self.add_particle(type_name='pds_virt', pos=pos, rotation=[False, False, False], dip=(ori * 1e-6))
+        particl_virt=self.add_particle(type_name='pds_virt', pos=pos, rotation=[False, False, False], director=ori, dipm=0.)
         particl_virt.vs_auto_relate_to(particl_real)
+        particl_virt.propagation = espressomd.propagation.Propagation.TRANS_VS_RELATIVE | espressomd.propagation.Propagation.ROT_VS_INDEPENDENT
 
-        # Very Important Particle. To use to bond, calculate distances, and other Very Important Things. Usually at the center of mass, and usually a real particle
-        self.vip = particl_real
+        particl_virt.is_magnetizable = True
+        particl_virt.magnetize_func = self.params["mag_func"]
+        particl_virt.dipm_sat = self.params["dipm"]
+        particl_virt.mag_susc_0 = self.params["Xi_0"]
 
         return self
     

--- a/pressomancy/simulation.py
+++ b/pressomancy/simulation.py
@@ -42,6 +42,8 @@ class Simulation():
         part_positions (list): A list of particle positions generated for the simulation.
         volume_size (float): The size of the volume assigned to each object.
         volume_centers (list): A list of centers of the partitioned volumes.
+        author_name (str): Default author name written to newly created HDF5 files.
+        author_email (str): Default author email written to newly created HDF5 files.
 
     Methods:
         __init__(box_dim):
@@ -129,6 +131,8 @@ class Simulation():
         self.volume_centers=[]
         self.io_dict={'h5_file': None,'properties':[('id',1), ('type',1), ('pos',3),('pos_folded',3), ('director',3),('image_box',3), ('f',3),('dip',3)],'flat_part_view':defaultdict(list),'registered_group_type': None}
         self.src_params_set=False
+        self.author_name="unknown"
+        self.author_email="unknown"
         # self.sys=espressomd.System(box_l=box_dim) is added and managed by the singleton decrator!
     
     def set_init_src(self, path, pos_ori_src_type=['real',], type_to_type_map=[], prop_to_prop_map=[], declare_types=[]):
@@ -592,6 +596,67 @@ class Simulation():
 
         return result
 
+    def set_author(self, name, email='unknown'):
+        """Set default author metadata for newly created HDF5 files."""
+        self.author_name = name
+        self.author_email = email
+             
+    def restore_part_types_from_metadata(self, h5_file, group_type):
+        """Restore ``part_types`` from optional HDF5 metadata or infer them from the file.
+
+        If ``/parameters/pressomancy/part_types`` is present, it is used as the
+        authoritative source. Otherwise a light fallback infers the mapping from a
+        single stored timestep together with the ownership connectivity datasets.
+        """
+        try:
+            part_types_group = h5_file["parameters/pressomancy/part_types"]
+        except KeyError:
+            part_types_group = None
+
+        if part_types_group is not None:
+            for key, value in part_types_group.attrs.items():
+                self.part_types.update({key: int(value)})
+            return
+
+        observed_numeric_types = set()
+        for grp_typ in group_type:
+            data_view = H5DataSelector(h5_file, particle_group=grp_typ.__name__)
+            observed_numeric_types.update(
+                int(val) for val in np.unique(data_view.timestep[-1].type)
+            )
+
+        object_names = set()
+        connectivity_root = h5_file.get("connectivity")
+        for particle_group in connectivity_root.values():
+            for dataset_name in particle_group.keys():
+                if not dataset_name.startswith("ParticleHandle_to_"):
+                    continue
+                object_names.add(dataset_name.removeprefix("ParticleHandle_to_"))
+
+        recovered = {}
+        unmatched = []
+        for numeric_type in sorted(observed_numeric_types):
+            matched_key = None
+            for object_name in sorted(object_names):
+                object_cls = globals().get(object_name)
+                for key, value in object_cls.part_types.items():
+                    if value == numeric_type:
+                        matched_key = key
+                        self.part_types.update({key: int(value)})
+                        break
+                if matched_key is not None:
+                    recovered[matched_key] = numeric_type
+                    break
+            if matched_key is None:
+                unmatched.append(numeric_type)
+
+        if recovered or unmatched:
+            logging.warning(
+                "Recovered part types from H5 fallback. Matched=%s Unmatched numeric types=%s",
+                recovered,
+                unmatched,
+            )
+
     def inscribe_part_group_to_h5(self, group_type=None, h5_data_path=None,mode='NEW',force_resize_to_size=None):
         """
         Inscribe one or more groups of simulation objects into an HDF5 file.
@@ -608,25 +673,36 @@ class Simulation():
             A list of `SimulationObject` subclasses. All instances of each
             class in `self.objects` will be registered and inscribed.
         h5_data_path : str
-            Path to the HDF5 file to write (mode='NEW') or append (mode='LOAD').
-        mode : {'NEW', 'LOAD'}, optional
+            Path to the HDF5 file to write or append.
+        mode : {'NEW', 'LOAD', 'LOAD_NEW', 'INIT_SRC'}, optional
             - 'NEW' : create a fresh file structure (default).
-            - 'LOAD': open existing file and resume writing.  
+            - 'LOAD': open an existing file and resume writing using the legacy path.
+            - 'LOAD_NEW': resume writing from HDF5 state and optional metadata.
+            - 'INIT_SRC': create a new file while populating particle data from a source file.
 
         Returns
         -------
         int
-            The starting global counter for writing time steps. Always 0 in
-            'NEW' mode; in 'LOAD' mode, the current number of already‑saved steps.
+            The starting global counter for writing time steps. This is 0 in
+            'NEW' and 'INIT_SRC' modes; for 'LOAD' and 'LOAD_NEW' it is the
+            current number of already-saved steps.
 
         Raises
         ------
         ValueError
-            If `mode` is not one of 'NEW' or 'LOAD'.
+            If `mode` is not one of 'NEW', 'LOAD', 'LOAD_NEW', or 'INIT_SRC'.
         ValueError
             If `group_type` is not a list.
         ValueError
-            In 'LOAD' mode, if different groups have mismatched saved step counts.
+            In load modes, if different groups have mismatched saved step counts.
+
+        Notes
+        -----
+        In 'NEW' and 'INIT_SRC' modes the method writes optional H5MD-style root
+        metadata under ``/h5md`` together with pressomancy-specific metadata under
+        ``/parameters/pressomancy``. In 'LOAD_NEW' mode this metadata is used as a
+        convenience source for restoring ``part_types`` when available, but it is
+        not required for successful resume.
         """
         if not isinstance(group_type, list):
             raise ValueError("group_type must be a list of classes.")
@@ -638,6 +714,24 @@ class Simulation():
 
         if mode in ['NEW', 'INIT_SRC']:
             self.io_dict['h5_file'] = h5py.File(h5_data_path, "w")
+            h5md_group = self.io_dict['h5_file'].require_group("h5md")
+            author_group = h5md_group.require_group("author")
+            creator_group = h5md_group.require_group("creator")
+            h5md_group.attrs["version"] = np.array([1, 0], dtype=np.int32)
+            author_group.attrs["name"] = self.author_name
+            author_group.attrs["email"] = self.author_email
+            creator_name, creator_version = get_submission_creator_info()
+            creator_group.attrs["name"] = creator_name
+            creator_group.attrs["version"] = creator_version
+            parameters_group = self.io_dict['h5_file'].require_group("parameters")
+            pressomancy_group = parameters_group.require_group("pressomancy")
+            _, pressomancy_version = get_repo_context(Path(__file__).resolve())
+            pressomancy_group.attrs["version"] = pressomancy_version
+            part_types_group = pressomancy_group.require_group("part_types")
+            for key, value in self.part_types.items():
+                if isinstance(value, (int, np.integer)):
+                    part_types_group.attrs[key] = int(value)
+            
             par_grp = self.io_dict['h5_file'].require_group(f"particles")
             for grp_typ in group_type:
                 data_grp = par_grp.require_group(grp_typ.__name__)
@@ -705,6 +799,7 @@ class Simulation():
         elif mode=='LOAD_NEW':
 
             self.io_dict['h5_file'] = h5py.File(h5_data_path, "a")
+            self.restore_part_types_from_metadata(self.io_dict['h5_file'], group_type)
             particles_group = self.io_dict['h5_file']["particles"]
             candidate_lens=[]
             for grp_typ in group_type:

--- a/pressomancy/simulation.py
+++ b/pressomancy/simulation.py
@@ -176,6 +176,8 @@ class Simulation():
         Method that checks if the object has the required features to be stored in the simulation. If the object has the required features it is stored in the self.objects list.
         '''
         if not all(api_agnostic_feature_check(feature) for feature in object.required_features):
+            print(espressomd.features())
+            print(set(object.required_features) - set(espressomd.features()))
             raise MissingFeature(f'{object.__class__.__name__} requires features: ',object.required_features)
 
     def store_objects(self, iterable_list, report=True):
@@ -224,7 +226,7 @@ class Simulation():
             If trying to place objects when more than one previous partition exists.
         Notes
         -----
-        The current implementation supports placing objects either in an empty system or in a system with exactly one previous partition. The method uses partition_cubic_volume to generate positions and orientations, and for subsequent placements, ensures no overlaps with existing objects through get_cross_lattice_nonintersecting_volumes. The method automatically adjusts the search space (by increasing the factor) if it cannot find enough non-overlapping positions in subsequent placements.
+        The current implementation supports placing objects either in an empty system or in a system with exactly one previous partition. The method uses partition_cuboid_volume to generate positions and orientations, and for subsequent placements, ensures no overlaps with existing objects through get_cross_lattice_nonintersecting_volumes. The method automatically adjusts the search space (by increasing the factor) if it cannot find enough non-overlapping positions in subsequent placements.
         """
         
         # Ensure all objects are of the same type.
@@ -235,7 +237,7 @@ class Simulation():
             # centeres, polymer_positions = partition_cubic_volume_oriented_rectangles(big_box_dim=self.sys.box_l, num_spheres=len(filaments), small_box_dim=np.array([filaments[0].sigma, filaments[0].sigma, filaments[0].size]), num_monomers=filaments[0].n_parts)
             if len(self.part_positions)== 0:
                 # First placement: generate exactly len(objects) positions.
-                centeres, positions, orientations = partition_cubic_volume(
+                centeres, positions, orientations = partition_cuboid_volume(
                     box_lengths=self.sys.box_l,
                     num_spheres=len(objects),
                     sphere_diameter=objects[0].params['size'],
@@ -248,7 +250,7 @@ class Simulation():
                 # Subsequent placements: search for positions without overlaps.
                 factor = 1
                 while True:
-                    centeres, positions, orientations = partition_cubic_volume(
+                    centeres, positions, orientations = partition_cuboid_volume(
                         box_lengths=self.sys.box_l,
                         num_spheres=len(objects) * factor,
                         sphere_diameter=objects[0].params['size'],

--- a/pressomancy/simulation.py
+++ b/pressomancy/simulation.py
@@ -175,10 +175,10 @@ class Simulation():
         '''
         Method that checks if the object has the required features to be stored in the simulation. If the object has the required features it is stored in the self.objects list.
         '''
-        if not all(api_agnostic_feature_check(feature) for feature in object.required_features):
-            print(espressomd.features())
-            print(set(object.required_features) - set(espressomd.features()))
-            raise MissingFeature(f'{object.__class__.__name__} requires features: ',object.required_features)
+        
+        missing_features = set(object.required_features) - set(espressomd.features())
+        if missing_features:
+            raise MissingFeature(f"Missing required features: {', '.join(missing_features)}")
 
     def store_objects(self, iterable_list, report=True):
         '''

--- a/pressomancy/simulation.py
+++ b/pressomancy/simulation.py
@@ -180,9 +180,8 @@ class Simulation():
         Method that checks if the object has the required features to be stored in the simulation. If the object has the required features it is stored in the self.objects list.
         '''
         
-        missing_features = set(object.required_features) - set(espressomd.features())
-        if missing_features:
-            raise MissingFeature(f"Missing required features: {', '.join(missing_features)}")
+        if not all(api_agnostic_feature_check(feature) for feature in object.required_features):
+            raise MissingFeature(f'{object.__class__.__name__} requires features: ',object.required_features)
 
     def store_objects(self, iterable_list, report=True):
         '''

--- a/samples/mae-BoS.py
+++ b/samples/mae-BoS.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.INFO)
                   
 espressomd.assert_features(['WCA', 'ROTATION', 'DIPOLES', 'DP3M',
                             'VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE',
-                            'EXTERNAL_FORCES', 'MAGNETIZE'])
+                            'EXTERNAL_FORCES'])
 
 from pressomancy.simulation import Simulation, Elastomer, PointDipolePermanent, PointDipoleSuperpara
 
@@ -20,7 +20,7 @@ import numpy as np
 #################
 
 # Simulation parameters
-sim_params = {'DENS_PART': 0.3, 'BOND_K': "soft", 'HEIGHT': 6,
+sim_params = {'DENS_PART': 0.3, 'BOND_K': "hard", 'HEIGHT': 6,
               'N_FULL_BOX': 120*4, 'seed': 1,
               'H': 1}
 
@@ -60,14 +60,21 @@ assert dens_A - DENS_PART < 0.001, f"DENS_{dens_A}"
 
 # INITIALIZE sim_inst
 sim_inst = Simulation(box_dim=box_l)
+sim_inst.reinitialize_instance()
+
 sim_inst.sys.box_l=box_l
 sim_inst.seed = sim_params['seed']
 sim_inst.set_sys(timestep=0.001)
 
-config_pdp = PointDipolePermanent.config.specify(dipm=1., espresso_handle=sim_inst.sys)
-config_pds = PointDipoleSuperpara.config.specify(dipm=1., Xi_0=0.1, espresso_handle=sim_inst.sys)
-n_pdp = int(N_PART/2); n_pds = N_PART - n_pdp
-associated_objects = [PointDipolePermanent(config=config_pdp) for _ in range(n_pdp)] + [PointDipoleSuperpara(config=config_pds) for _ in range(n_pds)]
+if espressomd.version.major()==5:
+    config_pdp = PointDipolePermanent.config.specify(dipm=1., espresso_handle=sim_inst.sys)
+    config_pds = PointDipoleSuperpara.config.specify(dipm=1., Xi_0=0.1, espresso_handle=sim_inst.sys)
+    n_pdp = int(N_PART/2); n_pds = N_PART - n_pdp
+    associated_objects = [PointDipolePermanent(config=config_pdp) for _ in range(n_pdp)] + [PointDipoleSuperpara(config=config_pds) for _ in range(n_pds)]
+elif espressomd.version.major()==4:
+    config_pdp = PointDipolePermanent.config.specify(dipm=1., espresso_handle=sim_inst.sys)
+    n_pdp = N_PART
+    associated_objects = [PointDipolePermanent(config=config_pdp) for _ in range(n_pdp)]
 assert len(associated_objects) == N_PART
 config_E = Elastomer.config.specify(layer_height=MAE_LAYER_HEIGHT, n_parts=N_PART, associated_objects=associated_objects, bond_K_lims=BOND_LIMITS_A, size=SIZE_PART, sigma=SIGMA_PART, espresso_handle=sim_inst.sys, seed=sim_inst.seed)
 elastomer=[Elastomer(config=config_E) for _ in range(1)]
@@ -75,7 +82,10 @@ sim_inst.store_objects(elastomer)
 sim_inst.set_objects(elastomer)
 elastomer= elastomer[0]
 
-sim_inst.set_steric(key=("pdp_real", "pds_real"))
+if espressomd.version.major()==5:
+    sim_inst.set_steric(key=("pdp_real", "pds_real"), sigma=SIGMA_PART)
+if espressomd.version.major()==4:
+    sim_inst.set_steric(key=("pdp_real",), sigma=SIGMA_PART)
 sim_inst.sys.integrator.run(0)
 
 # must add non_bonded interactions before creating substrate

--- a/samples/mae-BoS.py
+++ b/samples/mae-BoS.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.INFO)
                   
 espressomd.assert_features(['WCA', 'ROTATION', 'DIPOLES', 'DP3M',
                             'VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE',
-                            'EXTERNAL_FORCES'])
+                            'EXTERNAL_FORCES', 'MAGNETIZE'])
 
 from pressomancy.simulation import Simulation, Elastomer, PointDipolePermanent, PointDipoleSuperpara
 
@@ -53,9 +53,8 @@ assert MAE_LAYER_HEIGHT<=BOX_Z_MAX
 assert DENS_PART<=0.3
 
 box_l = [BOX_SIZE, BOX_SIZE, BOX_Z_MAX]
-box_E = [BOX_SIZE, BOX_SIZE, MAE_LAYER_HEIGHT]
 
-dens_A = N_PART * 4/3 * np.pi * R_PART**3 / np.prod(box_E)
+dens_A = N_PART * 4/3 * np.pi * R_PART**3 / np.prod([BOX_SIZE, BOX_SIZE, MAE_LAYER_HEIGHT])
 
 assert dens_A - DENS_PART < 0.001, f"DENS_{dens_A}"
 
@@ -66,11 +65,11 @@ sim_inst.seed = sim_params['seed']
 sim_inst.set_sys(timestep=0.001)
 
 config_pdp = PointDipolePermanent.config.specify(dipm=1., espresso_handle=sim_inst.sys)
-config_pds = PointDipoleSuperpara.config.specify(dipm=1., espresso_handle=sim_inst.sys)
+config_pds = PointDipoleSuperpara.config.specify(dipm=1., Xi_0=0.1, espresso_handle=sim_inst.sys)
 n_pdp = int(N_PART/2); n_pds = N_PART - n_pdp
 associated_objects = [PointDipolePermanent(config=config_pdp) for _ in range(n_pdp)] + [PointDipoleSuperpara(config=config_pds) for _ in range(n_pds)]
 assert len(associated_objects) == N_PART
-config_E = Elastomer.config.specify(box_E=box_E, n_parts=N_PART, associated_objects=associated_objects, bond_K_lims=BOND_LIMITS_A, size=SIZE_PART, sigma=SIGMA_PART, espresso_handle=sim_inst.sys, seed=sim_inst.seed)
+config_E = Elastomer.config.specify(layer_height=MAE_LAYER_HEIGHT, n_parts=N_PART, associated_objects=associated_objects, bond_K_lims=BOND_LIMITS_A, size=SIZE_PART, sigma=SIGMA_PART, espresso_handle=sim_inst.sys, seed=sim_inst.seed)
 elastomer=[Elastomer(config=config_E) for _ in range(1)]
 sim_inst.store_objects(elastomer)
 sim_inst.set_objects(elastomer)
@@ -80,20 +79,18 @@ sim_inst.set_steric(key=("pdp_real", "pds_real"))
 sim_inst.sys.integrator.run(0)
 
 # must add non_bonded interactions before creating substrate
-substrate_geometry = 'wall' if espressomd.version.major() == 4 else 'part'
-elastomer.create_substrate(geometry=substrate_geometry)
 energy = sim_inst.sys.analysis.energy()
 print("total",energy["total"])
 print("bonded",energy["bonded"])
 print("non_bonded",energy["non_bonded"])
 
 elastomer.mix_elastomer_stuff(test=True)
-elastomer.cure_elastomer(test=True)
+elastomer.cure_elastomer()
 
 #### Run the sample with external H ####
 
 # Add thermostat
-sim_inst.sys.thermostat.set_langevin(kT=1., gamma=1., seed=sim_inst.seed)
+sim_inst.sys.thermostat.set_langevin(kT=1e-3, gamma=10, seed=sim_inst.seed)
 
 # Add magnetic dipole interactions - direct sum, non-preiodic in z
 sim_inst.sys.periodicity = [True, True, False]
@@ -103,18 +100,6 @@ else:
     sim_inst.init_magnetic_inter(DipolarDirectSumCpu(prefactor=1))
 sim_inst.sys.integrator.run(0)
 
-# Mark particles to magnetize. Careful to use python lists, and not espressomd particle slices
-pds_to_magnetize = list(sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']))
-parts_to_magnetize = [[pds_to_magnetize, config_pds['dipm']],]
-
-# Gradually increasing dipole moments for permanent dipoles
-sim_inst.sys.time_step = 0.001
-for _ in range(10):
-   sim_inst.sys.integrator.run(1, recalc_forces=True)
-   for parts, dipm_pds in parts_to_magnetize:
-         sim_inst.magnetize(part_list=parts, dip_magnitude=dipm_pds, H_ext=np.asarray([0,0,1e-6]))
-
-
 # STABILIZE MAE WITH MAGNETIC FIELD
 sim_inst.sys.time = 0.
 
@@ -122,9 +107,6 @@ ext_B_z = sim_params['H']
 H_ext = [0,0,ext_B_z]
 sim_inst.set_H_ext(H=H_ext)
 
-for step in range(2):
-   sim_inst.sys.integrator.run(1, recalc_forces=True)
-   for parts, dipm in parts_to_magnetize:
-      sim_inst.magnetize(part_list=parts, dip_magnitude=dipm, H_ext=sim_inst.get_H_ext())
+sim_inst.sys.integrator.run(10)
 
 #################

--- a/samples/point_dipole.py
+++ b/samples/point_dipole.py
@@ -1,0 +1,275 @@
+import espressomd
+import espressomd.version
+if espressomd.version.major()==5:
+    from espressomd.magnetostatics import DipolarDirectSum
+elif espressomd.version.major()==4:
+    from espressomd.magnetostatics import DipolarDirectSumCpu
+else:
+    raise ImportError(f"Unsupported ESPResSo version: {espressomd.version}. Please use version 4 or 5.")
+import logging
+logging.basicConfig(level=logging.INFO)
+                  
+espressomd.assert_features(['WCA', 'ROTATION', 'DIPOLES', 'DP3M',
+                            'VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE',
+                            'EXTERNAL_FORCES', 'MAGNETIZE'])
+
+from pressomancy.simulation import Simulation, PointDipolePermanent, PointDipoleSuperpara
+
+import numpy as np
+
+#################
+
+box_l = [10,10,10]
+periodicity = [False, False, False]
+H = 1
+
+HM_dipm = 1.
+
+SM_dipm = 1.
+SM_Xi_0 = 0.1
+
+# INITIALIZE sim_inst
+sim_inst = Simulation(box_dim=box_l)
+sim_inst.sys.box_l=box_l
+sim_inst.seed = 1
+sim_inst.set_sys(timestep=0.1)
+
+pos = np.array([[0.,0.,0.],
+                [0.,0.,1.]])
+dip = np.array([[0.,0.,1.],
+                [0.,0.,1.]])
+
+config_pdp = PointDipolePermanent.config.specify(dipm=HM_dipm, espresso_handle=sim_inst.sys)
+config_pds = PointDipoleSuperpara.config.specify(dipm=SM_dipm, Xi_0=SM_Xi_0, mag_func=0, espresso_handle=sim_inst.sys)
+
+# Test one permanent point dipole with external H
+pdp_list = [PointDipolePermanent(config=config_pdp) for _ in range(1)]
+sim_inst.store_objects(pdp_list)
+sim_inst.set_objects(pdp_list) # set with random positions
+
+# put in the right position and dipoles
+i = 0
+for part in sim_inst.sys.part.select(type=sim_inst.part_types["pdp_real"]):
+    part.pos = pos[i]
+    part.dip = dip[i]
+    i+=1
+
+if espressomd.version.major()==5:
+    sim_inst.init_magnetic_inter(DipolarDirectSum(prefactor=1))
+else:
+    sim_inst.init_magnetic_inter(DipolarDirectSumCpu(prefactor=1))
+sim_inst.sys.integrator.run(0)
+sim_inst.set_H_ext(H=[0,0,H])
+
+sim_inst.sys.integrator.run(2)
+
+assert np.array_equal(sim_inst.sys.part.all().pos,pos[:1]), f"{sim_inst.sys.part.all().pos},\n{pos[:1]}"
+assert np.array_equal(sim_inst.sys.part.all().dip, dip[:1]), f"{sim_inst.sys.part.all().dip},\n{dip[:1]}"
+
+sim_inst.sys.part.clear()
+
+# Test one superparamagnetic point dipole with external H
+pds_list = [PointDipoleSuperpara(config=config_pds) for _ in range(1)]
+sim_inst.store_objects(pds_list)
+sim_inst.set_objects(pds_list) # set with random positions
+
+# put in the right position with 0 dipole
+i = 0
+for part in sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]):
+    part_real = sim_inst.sys.part.by_id(part.vs_relative[0])
+    part_real.pos = pos[i]
+    part.pos = pos[i]
+    i+=1
+
+if espressomd.version.major()==5:
+    sim_inst.init_magnetic_inter(DipolarDirectSum(prefactor=1))
+else:
+    sim_inst.init_magnetic_inter(DipolarDirectSumCpu(prefactor=1))
+sim_inst.sys.integrator.run(0)
+sim_inst.set_H_ext(H=[0,0,H])
+
+sim_inst.sys.integrator.run(2)
+
+dip_assert = np.array(dip[:1], copy=True)
+dip_assert[:,2] = 0.0994051
+
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos[:1]), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos},\n{pos[:1]}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos[:1]), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos},\n{pos[:1]}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip[:1]*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip},\n{dip[:1]*0.}"
+assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip},\n{dip_assert}"
+
+sim_inst.sys.part.clear()
+
+# Test two permanent point dipoles aligned in the same direction as the field
+pdp_list = [PointDipolePermanent(config=config_pdp) for _ in range(2)]
+sim_inst.store_objects(pdp_list)
+sim_inst.set_objects(pdp_list) # set with random positions
+
+# put in the right position and dipoles
+i = 0
+for part in sim_inst.sys.part.select(type=sim_inst.part_types["pdp_real"]):
+    part.pos = pos[i]
+    part.dip = dip[i]
+    i+=1
+
+# Fix because point dipoles will atract eachother without volume exclusion
+part_list = list(sim_inst.sys.part.select(type=sim_inst.part_types["pdp_real"]))
+for part in part_list:
+    part.fix = [True, True, True]
+
+if espressomd.version.major()==5:
+    sim_inst.init_magnetic_inter(DipolarDirectSum(prefactor=1))
+else:
+    sim_inst.init_magnetic_inter(DipolarDirectSumCpu(prefactor=1))
+sim_inst.sys.integrator.run(0)
+sim_inst.set_H_ext(H=[0,0,H])
+
+sim_inst.sys.integrator.run(2)
+
+assert np.array_equal(sim_inst.sys.part.all().pos, pos), f"{sim_inst.sys.part.all().pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.all().dip, dip), f"{sim_inst.sys.part.all().dip},\n{dip}"
+
+#test dipolar field
+dip_fld = np.array([[0,0,2],
+                    [0,0,2]])
+assert np.array_equal(sim_inst.sys.part.all().dip_fld, dip_fld), f"{sim_inst.sys.part.all().dip_fld},\n{dip_fld}"
+
+sim_inst.sys.part.clear()
+
+# Test two superparamagnetic point dipoles aligned in the same direction as the field (Langevin magnetization)
+pds_list = [PointDipoleSuperpara(config=config_pds) for _ in range(2)]
+sim_inst.store_objects(pds_list)
+sim_inst.set_objects(pds_list) # set with random positions
+
+# put in the right position with 0 dipole
+i = 0
+for part in sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]):
+    part_real = sim_inst.sys.part.by_id(part.vs_relative[0])
+    part_real.pos = pos[i]
+    part.pos = pos[i]
+    i+=1
+
+# Fix because point dipoles will atract eachother wihout volume exclusion
+part_list = list(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]))
+for part in part_list:
+    part.fix = [True, True, True]
+
+if espressomd.version.major()==5:
+    sim_inst.init_magnetic_inter(DipolarDirectSum(prefactor=1))
+else:
+    sim_inst.init_magnetic_inter(DipolarDirectSumCpu(prefactor=1))
+sim_inst.sys.integrator.run(0)
+sim_inst.set_H_ext(H=[0,0,H])
+
+sim_inst.sys.integrator.run(10)
+
+
+dip_assert = np.array(dip, copy=True)
+dip_assert[:,2] = 0.12356435
+
+#NOTE FOR TEST DEBUGGING. If the problem is the dipole momento modulus, try to increase the number of iterations by 1, until it works (probably just one more will do the trick). If the values are very close, something inside espresso might have changed this value.
+
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip},\n{dip*0.}"
+assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert, atol=0.00005, rtol=0), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip},\n{dip_assert}"
+
+poss_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos
+dips_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip
+
+sim_inst.sys.part.clear()
+
+# Test two superparamagnetic point dipoles aligned in the same direction as the field (Langevin magnetization) with higher susceptibylity - same as pressomancy magnetize
+config_pds = PointDipoleSuperpara.config.specify(dipm=SM_dipm, Xi_0=1./3., mag_func=0, espresso_handle=sim_inst.sys)
+pds_list = [PointDipoleSuperpara(config=config_pds) for _ in range(2)]
+sim_inst.store_objects(pds_list)
+sim_inst.set_objects(pds_list) # set with random positions
+
+# put in the right position with 0 dipole
+i = 0
+for part in sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]):
+    part_real = sim_inst.sys.part.by_id(part.vs_relative[0])
+    part_real.pos = pos[i]
+    part.pos = pos[i]
+    i+=1
+
+# Fix because point dipoles will atract eachother wihout volume exclusion
+part_list = list(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]))
+for part in part_list:
+    part.fix = [True, True, True]
+
+if espressomd.version.major()==5:
+    sim_inst.init_magnetic_inter(DipolarDirectSum(prefactor=1))
+else:
+    sim_inst.init_magnetic_inter(DipolarDirectSumCpu(prefactor=1))
+sim_inst.sys.integrator.run(0)
+sim_inst.set_H_ext(H=[0,0,H])
+
+sim_inst.sys.integrator.run(10)
+
+
+dip_assert = np.array(dip, copy=True)
+dip_assert[:,2] = 0.55634
+
+#NOTE FOR TEST DEBUGGING. If the problem is the dipole momento modulus, try to increase the number of iterations by 1, until it works (probably just one more will do the trick). If the values are very close, something inside espresso might have changed this value.
+
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip},\n{dip*0.}"
+assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert, atol=0.00005, rtol=0), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip},\n{dip_assert}"
+
+poss_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos
+dips_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip
+
+sim_inst.sys.part.clear()
+
+# Test two superparamagnetic point dipoles aligned in the same direction as the field (Langevin magnetization) - for pressomancy magnetize
+pds_list = [PointDipoleSuperpara(config=config_pds) for _ in range(2)]
+sim_inst.store_objects(pds_list)
+sim_inst.set_objects(pds_list) # set with random positions
+
+# put in the right position with 0 dipole
+i = 0
+for part in sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]):
+    part_real = sim_inst.sys.part.by_id(part.vs_relative[0])
+    part_real.pos = pos[i]
+    part.pos = pos[i]
+    i+=1
+
+# Fix because point dipoles will atract eachother wihout volume exclusion
+part_list = list(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]))
+for part in part_list:
+    part.fix = [True, True, True]
+
+if espressomd.version.major()==5:
+    sim_inst.init_magnetic_inter(DipolarDirectSum(prefactor=1))
+else:
+    sim_inst.init_magnetic_inter(DipolarDirectSumCpu(prefactor=1))
+sim_inst.sys.integrator.run(0)
+sim_inst.set_H_ext(H=[0,0,H])
+
+parts_to_magnetize = list(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]))
+for part in parts_to_magnetize:
+    part.is_magnetizable = False # remove espresso magnetization to compare to pressomancy magnetization
+
+H_ext = sim_inst.get_H_ext()
+assert np.array_equal(H_ext, [0,0,H])
+sim_inst.magnetize(parts_to_magnetize, SM_dipm, H_ext)
+for step in range(10):
+    sim_inst.sys.integrator.run(1)
+    sim_inst.magnetize(parts_to_magnetize, SM_dipm, H_ext)
+
+dip_assert = np.array(dip, copy=True)
+dip_assert[:,2] = 0.55634
+
+#NOTE FOR TEST DEBUGGING. If the problem is the dipole momento modulus, try to increase the number of iterations by 1, until it works (probably just one more will do the trick). If the values are very close, something inside espresso might have changed this value.
+
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip},\n{dip*0.}"
+assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert, atol=0.00005, rtol=0), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip},\n{dip_assert}"
+
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, poss_for_next_test), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos},\n{poss_for_next_test}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dips_for_next_test), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip},\n{dips_for_next_test}"
+
+sim_inst.sys.part.clear()

--- a/samples/point_dipole.py
+++ b/samples/point_dipole.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.INFO)
                   
 espressomd.assert_features(['WCA', 'ROTATION', 'DIPOLES', 'DP3M',
                             'VIRTUAL_SITES', 'VIRTUAL_SITES_RELATIVE',
-                            'EXTERNAL_FORCES', 'MAGNETIZE'])
+                            'EXTERNAL_FORCES'])
 
 from pressomancy.simulation import Simulation, PointDipolePermanent, PointDipoleSuperpara
 
@@ -93,10 +93,10 @@ sim_inst.sys.integrator.run(2)
 dip_assert = np.array(dip[:1], copy=True)
 dip_assert[:,2] = 0.0994051
 
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos[:1]), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos},\n{pos[:1]}"
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos[:1]), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos},\n{pos[:1]}"
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip[:1]*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip},\n{dip[:1]*0.}"
-assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip},\n{dip_assert}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos[:1]), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_real']).pos},\n{pos[:1]}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos[:1]), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).pos},\n{pos[:1]}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip[:1]*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_real']).dip},\n{dip[:1]*0.}"
+assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).dip},\n{dip_assert}"
 
 sim_inst.sys.part.clear()
 
@@ -169,13 +169,13 @@ dip_assert[:,2] = 0.12356435
 
 #NOTE FOR TEST DEBUGGING. If the problem is the dipole momento modulus, try to increase the number of iterations by 1, until it works (probably just one more will do the trick). If the values are very close, something inside espresso might have changed this value.
 
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos},\n{pos}"
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos},\n{pos}"
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip},\n{dip*0.}"
-assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert, atol=0.00005, rtol=0), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip},\n{dip_assert}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_real']).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_real']).dip},\n{dip*0.}"
+assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert, atol=0.00005, rtol=0), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).dip},\n{dip_assert}"
 
-poss_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos
-dips_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip
+poss_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).pos
+dips_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).dip
 
 sim_inst.sys.part.clear()
 
@@ -213,13 +213,13 @@ dip_assert[:,2] = 0.55634
 
 #NOTE FOR TEST DEBUGGING. If the problem is the dipole momento modulus, try to increase the number of iterations by 1, until it works (probably just one more will do the trick). If the values are very close, something inside espresso might have changed this value.
 
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos},\n{pos}"
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos},\n{pos}"
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip},\n{dip*0.}"
-assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert, atol=0.00005, rtol=0), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip},\n{dip_assert}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_real']).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_real']).dip},\n{dip*0.}"
+assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert, atol=0.00005, rtol=0), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).dip},\n{dip_assert}"
 
-poss_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos
-dips_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip
+poss_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).pos
+dips_for_next_test = sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).dip
 
 sim_inst.sys.part.clear()
 
@@ -264,12 +264,12 @@ dip_assert[:,2] = 0.55634
 
 #NOTE FOR TEST DEBUGGING. If the problem is the dipole momento modulus, try to increase the number of iterations by 1, until it works (probably just one more will do the trick). If the values are very close, something inside espresso might have changed this value.
 
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos},\n{pos}"
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos},\n{pos}"
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip},\n{dip*0.}"
-assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert, atol=0.00005, rtol=0), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip},\n{dip_assert}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_real']).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, pos), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).pos},\n{pos}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]).dip, dip*0.), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_real']).dip},\n{dip*0.}"
+assert np.allclose(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dip_assert, atol=0.00005, rtol=0), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).dip},\n{dip_assert}"
 
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, poss_for_next_test), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos},\n{poss_for_next_test}"
-assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dips_for_next_test), f"{sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip},\n{dips_for_next_test}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).pos, poss_for_next_test), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).pos},\n{poss_for_next_test}"
+assert np.array_equal(sim_inst.sys.part.select(type=sim_inst.part_types["pds_virt"]).dip, dips_for_next_test), f"{sim_inst.sys.part.select(type=sim_inst.part_types['pds_virt']).dip},\n{dips_for_next_test}"
 
 sim_inst.sys.part.clear()

--- a/test/test_IO.py
+++ b/test/test_IO.py
@@ -7,8 +7,11 @@ from pressomancy.analysis import H5DataSelector
 import h5py
 import tempfile
 import os
+from pathlib import Path
 from pressomancy.helper_functions import MissingFeature
 import logging
+from unittest.mock import patch
+import pressomancy.simulation as simulation_module
 
 class IOTest(BaseTestCase):
 
@@ -189,6 +192,83 @@ class IOTest(BaseTestCase):
             self.slicing_check(data)
             GLOBAL_COUNTER=sim_inst.inscribe_part_group_to_h5(group_type=[Filament, Crowder], h5_data_path=h5_filename,mode='LOAD_NEW')
             GLOBAL_COUNTER=sim_inst.inscribe_part_group_to_h5(group_type=[Filament, Crowder], h5_data_path=h5_filename,mode='LOAD')
+
+    def test_h5md_optional_metadata_and_load_new_recovery(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            h5_filename = os.path.join(tmpdirname, "testfile.h5")
+            with patch.object(simulation_module, "get_submission_creator_info", return_value=("UPLOAD_VIEW/suspensions/mcp_suspension_pressomancy.py", "main@abc1234-dirty")), patch.object(simulation_module, "get_repo_context", return_value=(Path("/home/stekajack/pressomancy"), "main@def5678-dirty")):
+                GLOBAL_COUNTER = sim_inst.inscribe_part_group_to_h5(group_type=[Filament, Crowder], h5_data_path=h5_filename)
+            sim_inst.sys.integrator.run(1)
+            sim_inst.write_part_group_to_h5(time_step=GLOBAL_COUNTER)
+
+            h5_handle = sim_inst.io_dict['h5_file']
+            self.assertIn("h5md", h5_handle)
+            np.testing.assert_array_equal(h5_handle["h5md"].attrs["version"], np.array([1, 0], dtype=np.int32))
+            self.assertEqual(h5_handle["h5md/author"].attrs["name"], "unknown")
+            self.assertEqual(h5_handle["h5md/creator"].attrs["name"], "UPLOAD_VIEW/suspensions/mcp_suspension_pressomancy.py")
+            self.assertEqual(h5_handle["h5md/creator"].attrs["version"], "main@abc1234-dirty")
+            self.assertEqual(h5_handle["parameters/pressomancy"].attrs["version"], "main@def5678-dirty")
+            self.assertEqual(h5_handle["parameters/pressomancy/part_types"].attrs["real"], 1)
+
+            data = H5DataSelector(h5_handle, particle_group="Filament")
+            np.testing.assert_array_equal(data.metadata["h5md"]["_meta"]["attributes"]["version"], np.array([1, 0], dtype=np.int32))
+            self.assertEqual(data.metadata["h5md"]["creator"]["_meta"]["attributes"]["name"], "UPLOAD_VIEW/suspensions/mcp_suspension_pressomancy.py")
+            self.assertEqual(data.metadata["parameters"]["pressomancy"]["_meta"]["attributes"]["version"], "main@def5678-dirty")
+            self.assertEqual(data.metadata["parameters"]["pressomancy"]["part_types"]["_meta"]["attributes"]["real"], 1)
+
+            original_part_types = {key: value for key, value in sim_inst.part_types.items() if isinstance(value, int)}
+            sim_inst.part_types.clear()
+            sim_inst.inscribe_part_group_to_h5(group_type=[Filament, Crowder], h5_data_path=h5_filename,mode='LOAD_NEW')
+            for key, value in original_part_types.items():
+                self.assertEqual(dict.get(sim_inst.part_types, key), value)
+            sim_inst.io_dict['h5_file'].close()
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            h5_filename = os.path.join(tmpdirname, "testfile_legacy.h5")
+            GLOBAL_COUNTER = sim_inst.inscribe_part_group_to_h5(group_type=[Filament, Crowder], h5_data_path=h5_filename)
+            sim_inst.sys.integrator.run(1)
+            sim_inst.write_part_group_to_h5(time_step=GLOBAL_COUNTER)
+            h5_handle = sim_inst.io_dict['h5_file']
+            del h5_handle["parameters/pressomancy/part_types"]
+            h5_handle["particles/Filament/type/value"][-1, 0, 0] = 999
+            h5_handle.flush()
+            h5_handle.close()
+
+            sim_inst.part_types.clear()
+            with self.assertLogs(level="WARNING") as log_context:
+                sim_inst.inscribe_part_group_to_h5(group_type=[Filament, Crowder], h5_data_path=h5_filename, mode='LOAD_NEW')
+            self.assertEqual(dict.get(sim_inst.part_types, "real"), 1)
+            self.assertTrue(any("Unmatched numeric types=[999]" in entry for entry in log_context.output))
+            sim_inst.io_dict['h5_file'].close()
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            h5_filename = os.path.join(tmpdirname, "testfile_author.h5")
+            sim_inst.set_author("Alice", "alice@example.com")
+            with patch.object(simulation_module, "get_submission_creator_info", return_value=("unknown/mcp_suspension_pressomancy.py", "unknown")), patch.object(simulation_module, "get_repo_context", return_value=(None, "unknown")):
+                sim_inst.inscribe_part_group_to_h5(group_type=[Filament, Crowder], h5_data_path=h5_filename)
+            h5_handle = sim_inst.io_dict['h5_file']
+            self.assertEqual(h5_handle["h5md/author"].attrs["name"], "Alice")
+            self.assertEqual(h5_handle["h5md/author"].attrs["email"], "alice@example.com")
+            self.assertEqual(h5_handle["h5md/creator"].attrs["name"], "unknown/mcp_suspension_pressomancy.py")
+            self.assertEqual(h5_handle["parameters/pressomancy"].attrs["version"], "unknown")
+            h5_handle.close()
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            h5_filename = os.path.join(tmpdirname, "testfile_src.h5")
+            dest_filename = os.path.join(tmpdirname, "testfile_src_shrunk.h5")
+            with patch.object(simulation_module, "get_submission_creator_info", return_value=("UPLOAD_VIEW/suspensions/mcp_suspension_pressomancy.py", "main@abc1234-dirty")), patch.object(simulation_module, "get_repo_context", return_value=(Path("/home/stekajack/pressomancy"), "main@def5678-dirty")):
+                GLOBAL_COUNTER = sim_inst.inscribe_part_group_to_h5(group_type=[Filament, Crowder], h5_data_path=h5_filename)
+            sim_inst.sys.integrator.run(1)
+            sim_inst.write_part_group_to_h5(time_step=GLOBAL_COUNTER)
+            sim_inst.io_dict['h5_file'].flush()
+            sim_inst.io_dict['h5_file'].close()
+            sim_inst.mk_src_file(h5_filename, dest_filename, time_step=0)
+
+            with h5py.File(dest_filename, "r") as h5_file:
+                self.assertEqual(h5_file["h5md/creator"].attrs["name"], "UPLOAD_VIEW/suspensions/mcp_suspension_pressomancy.py")
+                self.assertEqual(h5_file["h5md/creator"].attrs["version"], "main@abc1234-dirty")
+                self.assertEqual(h5_file["parameters/pressomancy"].attrs["version"], "main@def5678-dirty")
+                self.assertEqual(h5_file["parameters/pressomancy/part_types"].attrs["real"], 1)
 
     def test_obsolete_IO(self):
         with tempfile.TemporaryDirectory() as tmpdirname:

--- a/test/test_box_partitioning.py
+++ b/test/test_box_partitioning.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pressomancy.simulation import partition_cubic_volume, get_neighbours, get_neighbours_cross_lattice
+from pressomancy.simulation import partition_cuboid_volume, get_neighbours, get_neighbours_cross_lattice
 from create_system import BaseTestCase
 
 class PartitioningTest(BaseTestCase):
@@ -14,7 +14,7 @@ class PartitioningTest(BaseTestCase):
 
     def test_get_neighbours(self):
         control= {0: [2,], 1: [2,],2: [0, 1, 3, 4,], 3: [2, ], 4: [2,]}
-        sphere_centers_short, _,_=partition_cubic_volume(np.ones(3) * self.box_len,self.num_vol_side,self.sph_diam, flag='norand')
+        sphere_centers_short, _,_=partition_cuboid_volume(np.ones(3) * self.box_len,self.num_vol_side,self.sph_diam, flag='norand')
         neigh=get_neighbours(sphere_centers_short,np.ones(3) * self.box_len,cuttoff=self.sph_diam)
         neigh_sets = {key: set(val) for key, val in neigh.items()}
         control_sets = {key: set(val) for key, val in control.items()}
@@ -23,9 +23,9 @@ class PartitioningTest(BaseTestCase):
     def test_get_neighbours_cross_lattice(self):
         
         control={0: [0, 2, 5, 6], 1: [1, 2, 5, 7], 2: [0, 1, 2, 3, 4, 5, 6, 7, 8], 3: [2, 3, 6, 8], 4: [2, 4, 7, 8]}
-        sphere_centers_long, _,_=partition_cubic_volume(np.ones(3) * self.box_len,self.num_vol_all,self.sph_diam,flag='norand')
+        sphere_centers_long, _,_=partition_cuboid_volume(np.ones(3) * self.box_len,self.num_vol_all,self.sph_diam,flag='norand')
 
-        sphere_centers_short, _,_=partition_cubic_volume(np.ones(3) * self.box_len,self.num_vol_side,self.sph_diam,flag='norand')
+        sphere_centers_short, _,_=partition_cuboid_volume(np.ones(3) * self.box_len,self.num_vol_side,self.sph_diam,flag='norand')
 
         neigh=get_neighbours_cross_lattice(sphere_centers_short,sphere_centers_long,np.ones(3) * self.box_len,cuttoff=self.sph_diam)
         self.assertEqual(neigh,control,'the get_neighbour method failed to reproduce correct neighbour pairs for a single face of an fcc lattice')  

--- a/test/test_elastomer.py
+++ b/test/test_elastomer.py
@@ -68,7 +68,7 @@ class ElastomerTest(BaseTestCase):
         n_bonds_per_part_list = [len(bonds) for bonds in n_bond_dict.values()]
         assert min(n_bonds_per_part_list) > 0, f"{n_bonds_per_part_list}"
         dist_bonds_per_part_list = [np.linalg.norm(part.pos - sim_inst.sys.part.by_id(id).pos) for part in sim_inst.sys.part.select(type=sim_inst.part_types["pdp_real"]) for bond, id in part.bonds]
-        assert max(dist_bonds_per_part_list) <= 5.
+        assert max(dist_bonds_per_part_list) <= 5.001, f"{max(dist_bonds_per_part_list)}"
 
     def test_cure_bad_elastomer(self): # tests if the function to assure at least 1 neighboor is working
         from collections import defaultdict

--- a/test/test_elastomer.py
+++ b/test/test_elastomer.py
@@ -1,6 +1,11 @@
-from pressomancy.simulation import Elastomer, PointDipoleSuperpara
+from pressomancy.simulation import Elastomer, PointDipolePermanent
 from create_system import sim_inst, BaseTestCase
 import numpy as np
+
+import espressomd
+assert espressomd.version.major() in (4,5)
+
+from itertools import combinations_with_replacement
 
 class ElastomerTest(BaseTestCase):
     box_E = [3,3,9]
@@ -17,7 +22,7 @@ class ElastomerTest(BaseTestCase):
         sim_inst.set_objects([instance])
 
     def test_set_object(self):
-        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+        mag_part = [PointDipolePermanent(config=PointDipolePermanent.config.specify(dipm=1.,
             espresso_handle=sim_inst.sys)) for _ in range(10)]
         sim_inst.store_objects(mag_part)
         instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
@@ -27,7 +32,7 @@ class ElastomerTest(BaseTestCase):
         sim_inst.set_objects([instance])
 
     def test_mix_elastomer(self):
-        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+        mag_part = [PointDipolePermanent(config=PointDipolePermanent.config.specify(dipm=1.,
             espresso_handle=sim_inst.sys)) for _ in range(10)]
         sim_inst.store_objects(mag_part)
         instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
@@ -43,7 +48,7 @@ class ElastomerTest(BaseTestCase):
 
     def test_cure_elastomer(self):
         from collections import defaultdict
-        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+        mag_part = [PointDipolePermanent(config=PointDipolePermanent.config.specify(dipm=1.,
             espresso_handle=sim_inst.sys)) for _ in range(10)]
         sim_inst.store_objects(mag_part)
         instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
@@ -55,14 +60,14 @@ class ElastomerTest(BaseTestCase):
         instance.cure_elastomer()
 
         n_bond_dict = defaultdict(list)
-        for part in sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]):
+        for part in sim_inst.sys.part.select(type=sim_inst.part_types["pdp_real"]):
             for bond in part.bonds:
                 n_bond_dict[part.id].append(bond[1])
                 n_bond_dict[bond[1]].append(part.id)
 
         n_bonds_per_part_list = [len(bonds) for bonds in n_bond_dict.values()]
         assert min(n_bonds_per_part_list) > 0, f"{n_bonds_per_part_list}"
-        dist_bonds_per_part_list = [np.linalg.norm(part.pos - sim_inst.sys.part.by_id(id).pos) for part in sim_inst.sys.part.select(type=62) for bond, id in part.bonds]
+        dist_bonds_per_part_list = [np.linalg.norm(part.pos - sim_inst.sys.part.by_id(id).pos) for part in sim_inst.sys.part.select(type=sim_inst.part_types["pdp_real"]) for bond, id in part.bonds]
         assert max(dist_bonds_per_part_list) <= 5.
 
     def test_cure_bad_elastomer(self): # tests if the function to assure at least 1 neighboor is working
@@ -86,7 +91,7 @@ class ElastomerTest(BaseTestCase):
         assert min(n_bonds_per_part_list) >= 3, f"{n_bonds_per_part_list}"
 
     def test_substrate(self):
-        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+        mag_part = [PointDipolePermanent(config=PointDipolePermanent.config.specify(dipm=1.,
             espresso_handle=sim_inst.sys)) for _ in range(10)]
         sim_inst.store_objects(mag_part)
         instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
@@ -108,7 +113,7 @@ class ElastomerTest(BaseTestCase):
         assert set(map(tuple, np.asarray([p.pos for p in instance.substrate]))) == set(map(tuple, substrate_pos)), f"{[p.pos for p in instance.substrate]}"
     
     def test_remove_substrate(self):
-        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+        mag_part = [PointDipolePermanent(config=PointDipolePermanent.config.specify(dipm=1.,
             espresso_handle=sim_inst.sys)) for _ in range(10)]
         sim_inst.store_objects(mag_part)
         instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
@@ -122,7 +127,7 @@ class ElastomerTest(BaseTestCase):
         assert len(sim_inst.sys.part.select(type=sim_inst.part_types["substrate"])) == 0
 
     def test_wall_substrate(self):
-        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+        mag_part = [PointDipolePermanent(config=PointDipolePermanent.config.specify(dipm=1.,
             espresso_handle=sim_inst.sys)) for _ in range(10)]
         sim_inst.store_objects(mag_part)
         instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
@@ -135,8 +140,8 @@ class ElastomerTest(BaseTestCase):
 
         instance.create_substrate(geometry="wall")
     
-    def test_elastome_with_wall_substrate(self):
-        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+    def test_elastomer_with_wall_substrate(self):
+        mag_part = [PointDipolePermanent(config=PointDipolePermanent.config.specify(dipm=1.,
             espresso_handle=sim_inst.sys)) for _ in range(10)]
         sim_inst.store_objects(mag_part)
         instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
@@ -156,3 +161,36 @@ class ElastomerTest(BaseTestCase):
         instance.mix_elastomer_stuff(test=True)
 
         instance.cure_elastomer()
+
+    
+    if espressomd.version.major() == 5:
+        from pressomancy.simulation import PointDipoleSuperpara
+        def test_elastomer_witt_PointDipoleSuperpara(self):
+            from collections import defaultdict
+            mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+                espresso_handle=sim_inst.sys)) for _ in range(10)]
+            sim_inst.store_objects(mag_part)
+            instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
+                n_parts=10, size=self.part_size,espresso_handle=sim_inst.sys,seed=sim_inst.seed,
+                associated_objects=mag_part))
+            sim_inst.store_objects([instance])
+            sim_inst.set_objects([instance])
+
+            sim_inst.set_steric(tuple((type_name for type_name in instance.part_types.keys() if "real" in type_name)))
+
+            sim_inst.sys.time_step = 0.01
+
+            instance.mix_elastomer_stuff(test=True)
+
+            instance.cure_elastomer()
+
+            n_bond_dict = defaultdict(list)
+            for part in sim_inst.sys.part.select(type=sim_inst.part_types["pdp_real"]):
+                for bond in part.bonds:
+                    n_bond_dict[part.id].append(bond[1])
+                    n_bond_dict[bond[1]].append(part.id)
+
+            n_bonds_per_part_list = [len(bonds) for bonds in n_bond_dict.values()]
+            assert min(n_bonds_per_part_list) > 0, f"{n_bonds_per_part_list}"
+            dist_bonds_per_part_list = [np.linalg.norm(part.pos - sim_inst.sys.part.by_id(id).pos) for part in sim_inst.sys.part.select(type=62) for bond, id in part.bonds]
+            assert max(dist_bonds_per_part_list) <= 5.

--- a/test/test_elastomer.py
+++ b/test/test_elastomer.py
@@ -4,6 +4,8 @@ import numpy as np
 
 import espressomd
 assert espressomd.version.major() in (4,5)
+if espressomd.version.major() == 5:
+    from pressomancy.simulation import PointDipoleSuperpara
 
 from itertools import combinations_with_replacement
 
@@ -164,7 +166,6 @@ class ElastomerTest(BaseTestCase):
 
     
     if espressomd.version.major() == 5:
-        from pressomancy.simulation import PointDipoleSuperpara
         def test_elastomer_witt_PointDipoleSuperpara(self):
             from collections import defaultdict
             mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
@@ -185,7 +186,7 @@ class ElastomerTest(BaseTestCase):
             instance.cure_elastomer()
 
             n_bond_dict = defaultdict(list)
-            for part in sim_inst.sys.part.select(type=sim_inst.part_types["pdp_real"]):
+            for part in sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]):
                 for bond in part.bonds:
                     n_bond_dict[part.id].append(bond[1])
                     n_bond_dict[bond[1]].append(part.id)

--- a/test/test_elastomer.py
+++ b/test/test_elastomer.py
@@ -1,0 +1,158 @@
+from pressomancy.simulation import Elastomer, PointDipoleSuperpara
+from create_system import sim_inst, BaseTestCase
+import numpy as np
+
+class ElastomerTest(BaseTestCase):
+    box_E = [3,3,9]
+
+    part_size=1.
+
+    def tearDown(self) -> None:
+        sim_inst.reinitialize_instance()
+        self.assertEqual(len(sim_inst.sys.part),0)
+
+    def test_set_object_generic(self):
+        instance=Elastomer(config=Elastomer.config.specify(espresso_handle=sim_inst.sys))
+        sim_inst.store_objects([instance])
+        sim_inst.set_objects([instance])
+
+    def test_set_object(self):
+        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+            espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
+            n_parts=10, size=self.part_size,espresso_handle=sim_inst.sys,seed=sim_inst.seed,
+            associated_objects=mag_part))
+        sim_inst.store_objects([instance])
+        sim_inst.set_objects([instance])
+
+    def test_mix_elastomer(self):
+        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+            espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
+            n_parts=10, size=self.part_size,espresso_handle=sim_inst.sys,seed=sim_inst.seed,
+            associated_objects=mag_part))
+        sim_inst.store_objects([instance])
+        sim_inst.set_objects([instance])
+
+        sim_inst.set_steric(tuple((type_name for type_name in instance.part_types.keys() if "real" in type_name)))
+
+        sim_inst.sys.time_step = 0.01
+        instance.mix_elastomer_stuff(test=True)
+
+    def test_cure_elastomer(self):
+        from collections import defaultdict
+        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+            espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
+            n_parts=10, size=self.part_size,espresso_handle=sim_inst.sys,seed=sim_inst.seed,
+            associated_objects=mag_part))
+        sim_inst.store_objects([instance])
+        sim_inst.set_objects([instance])
+
+        instance.cure_elastomer()
+
+        n_bond_dict = defaultdict(list)
+        for part in sim_inst.sys.part.select(type=sim_inst.part_types["pds_real"]):
+            for bond in part.bonds:
+                n_bond_dict[part.id].append(bond[1])
+                n_bond_dict[bond[1]].append(part.id)
+
+        n_bonds_per_part_list = [len(bonds) for bonds in n_bond_dict.values()]
+        assert min(n_bonds_per_part_list) > 0, f"{n_bonds_per_part_list}"
+        dist_bonds_per_part_list = [np.linalg.norm(part.pos - sim_inst.sys.part.by_id(id).pos) for part in sim_inst.sys.part.select(type=62) for bond, id in part.bonds]
+        assert max(dist_bonds_per_part_list) <= 5.
+
+    def test_cure_bad_elastomer(self): # tests if the function to assure at least 1 neighboor is working
+        from collections import defaultdict
+        instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
+            n_parts=10, size=self.part_size,
+            bond_cutoff=0.9,
+            espresso_handle=sim_inst.sys,seed=sim_inst.seed))
+        sim_inst.store_objects([instance])
+        sim_inst.set_objects([instance])
+
+        instance.cure_elastomer(test_bad=True)
+
+        n_bond_dict = defaultdict(list)
+        for part in sim_inst.sys.part.select(type=sim_inst.part_types["real"]):
+            for bond in part.bonds:
+                n_bond_dict[part.id].append(bond[1])
+                n_bond_dict[bond[1]].append(part.id)
+
+        n_bonds_per_part_list = [len(bonds) for bonds in n_bond_dict.values()]
+        assert min(n_bonds_per_part_list) >= 3, f"{n_bonds_per_part_list}"
+
+    def test_substrate(self):
+        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+            espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
+            n_parts=10, size=self.part_size,espresso_handle=sim_inst.sys,seed=sim_inst.seed,
+            associated_objects=mag_part))
+        sim_inst.store_objects([instance])
+        sim_inst.set_objects([instance])
+
+        substrate_pos = np.asarray([[ 0.5,0.5, 0.5],
+                                    [ 1.5,0.5, 0.5],
+                                    [ 2.5,0.5, 0.5],
+                                    [ 0.5,1.5, 0.5],
+                                    [ 1.5,1.5, 0.5],
+                                    [ 2.5,1.5, 0.5],
+                                    [ 0.5,2.5, 0.5],
+                                    [ 1.5,2.5, 0.5],
+                                    [ 2.5,2.5, 0.5]])
+
+        assert set(map(tuple, np.asarray([p.pos for p in instance.substrate]))) == set(map(tuple, substrate_pos)), f"{[p.pos for p in instance.substrate]}"
+    
+    def test_remove_substrate(self):
+        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+            espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
+            n_parts=10, size=self.part_size,espresso_handle=sim_inst.sys,seed=sim_inst.seed,
+            associated_objects=mag_part))
+        sim_inst.store_objects([instance])
+        sim_inst.set_objects([instance])
+
+        instance.remove_substrate()
+
+        assert len(sim_inst.sys.part.select(type=sim_inst.part_types["substrate"])) == 0
+
+    def test_wall_substrate(self):
+        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+            espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
+            n_parts=10, size=self.part_size,espresso_handle=sim_inst.sys,seed=sim_inst.seed,
+            associated_objects=mag_part))
+        sim_inst.store_objects([instance])
+        sim_inst.set_objects([instance])
+
+        instance.remove_substrate()
+
+        instance.create_substrate(geometry="wall")
+    
+    def test_elastome_with_wall_substrate(self):
+        mag_part = [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(dipm=1.,
+            espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        instance=Elastomer(config=Elastomer.config.specify(box_E=self.box_E,
+            n_parts=10, size=self.part_size,espresso_handle=sim_inst.sys,seed=sim_inst.seed,
+            associated_objects=mag_part))
+        sim_inst.store_objects([instance])
+        sim_inst.set_objects([instance])
+
+        instance.remove_substrate()
+
+        instance.create_substrate(geometry="wall")
+
+        sim_inst.set_steric(tuple((type_name for type_name in instance.part_types.keys() if "real" in type_name)))
+
+        sim_inst.sys.time_step = 0.01
+
+        instance.mix_elastomer_stuff(test=True)
+
+        instance.cure_elastomer()

--- a/test/test_point_dipole.py
+++ b/test/test_point_dipole.py
@@ -1,5 +1,10 @@
-from pressomancy.simulation import PointDipolePermanent, PointDipoleSuperpara
+from pressomancy.simulation import PointDipolePermanent
 from create_system import sim_inst, BaseTestCase
+
+import espressomd
+
+if espressomd.version.major() == 5:
+    from pressomancy.simulation import PointDipoleSuperpara
 
 class PointDipoleTest(BaseTestCase):
     H_ext = [0,0,3.]
@@ -12,10 +17,12 @@ class PointDipoleTest(BaseTestCase):
         mag_part = [PointDipolePermanent(config=PointDipolePermanent.config.specify(espresso_handle=sim_inst.sys)) for _ in range(10)]
         sim_inst.store_objects(mag_part)
         sim_inst.set_objects(mag_part)
-        mag_part =  [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(espresso_handle=sim_inst.sys)) for _ in range(10)]
-        sim_inst.store_objects(mag_part)
-        sim_inst.set_objects(mag_part)
-        assert sim_inst.part_types["pds_real"] == 62 and sim_inst.part_types["pds_virt"] == 666
+        assert sim_inst.part_types["pdp_real"] == 61
+        if espressomd.version.major() == 5:
+            mag_part =  [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(espresso_handle=sim_inst.sys)) for _ in range(10)]
+            sim_inst.store_objects(mag_part)
+            sim_inst.set_objects(mag_part)
+            assert sim_inst.part_types["pds_real"] == 62 and sim_inst.part_types["pds_virt"] == 666
 
     def test_set_object(self):
         mag_part = [PointDipolePermanent(
@@ -23,49 +30,51 @@ class PointDipoleTest(BaseTestCase):
                     espresso_handle=sim_inst.sys)) for _ in range(10)]
         sim_inst.store_objects(mag_part)
         sim_inst.set_objects(mag_part)
-        mag_part = [PointDipoleSuperpara(
-                    config=PointDipoleSuperpara.config.specify(dipm=1., Xi_0=0.1, size=0.5,
-                    espresso_handle=sim_inst.sys)) for _ in range(10)]
-        sim_inst.store_objects(mag_part)
-        sim_inst.set_objects(mag_part)
+        if espressomd.version.major() == 5:
+            mag_part = [PointDipoleSuperpara(
+                        config=PointDipoleSuperpara.config.specify(dipm=1., Xi_0=0.1, size=0.5,
+                        espresso_handle=sim_inst.sys)) for _ in range(10)]
+            sim_inst.store_objects(mag_part)
+            sim_inst.set_objects(mag_part)
 
-    def test_magnetize_PointDipoleSuperpara(self):
-        mag_part = [PointDipoleSuperpara(
-                    config=PointDipoleSuperpara.config.specify(dipm=1., size=0.5,
-                    espresso_handle=sim_inst.sys)) for _ in range(10)]
-        sim_inst.store_objects(mag_part)
-        sim_inst.set_objects(mag_part)
+    if espressomd.version.major() == 5:
+        def test_magnetize_PointDipoleSuperpara(self):
+            mag_part = [PointDipoleSuperpara(
+                        config=PointDipoleSuperpara.config.specify(dipm=1., size=0.5,
+                        espresso_handle=sim_inst.sys)) for _ in range(10)]
+            sim_inst.store_objects(mag_part)
+            sim_inst.set_objects(mag_part)
 
-        sim_inst.time_step = 0.001
-        sim_inst.sys.integrator.run(0, recalc_forces=True)
+            sim_inst.time_step = 0.001
+            sim_inst.sys.integrator.run(0, recalc_forces=True)
 
-    def test_magnetize_mixture(self):
-        mag_part_pds = [PointDipoleSuperpara(
-                    config=PointDipoleSuperpara.config.specify(dipm=1., size=0.5,
-                    espresso_handle=sim_inst.sys)) for _ in range(10)]
-        sim_inst.store_objects(mag_part_pds)
-        sim_inst.set_objects(mag_part_pds)
-        mag_part_pdp = [PointDipolePermanent(
-                    config=PointDipolePermanent.config.specify(dipm=0.7, size=2.,
-                    espresso_handle=sim_inst.sys)) for _ in range(10)]
-        sim_inst.store_objects(mag_part_pdp)
-        sim_inst.set_objects(mag_part_pdp)
+        def test_magnetize_mixture(self):
+            mag_part_pds = [PointDipoleSuperpara(
+                        config=PointDipoleSuperpara.config.specify(dipm=1., size=0.5,
+                        espresso_handle=sim_inst.sys)) for _ in range(10)]
+            sim_inst.store_objects(mag_part_pds)
+            sim_inst.set_objects(mag_part_pds)
+            mag_part_pdp = [PointDipolePermanent(
+                        config=PointDipolePermanent.config.specify(dipm=0.7, size=2.,
+                        espresso_handle=sim_inst.sys)) for _ in range(10)]
+            sim_inst.store_objects(mag_part_pdp)
+            sim_inst.set_objects(mag_part_pdp)
 
-        sim_inst.time_step = 0.001
-        sim_inst.sys.integrator.run(0, recalc_forces=True)
+            sim_inst.time_step = 0.001
+            sim_inst.sys.integrator.run(0, recalc_forces=True)
 
-    def test_magnetize_Froelich_Kennelly(self):
-        mag_part_pds = [PointDipoleSuperpara(
-                    config=PointDipoleSuperpara.config.specify(dipm=1., mag_func=1, size=0.5,
-                    espresso_handle=sim_inst.sys)) for _ in range(10)]
-        sim_inst.store_objects(mag_part_pds)
-        sim_inst.set_objects(mag_part_pds)
-        mag_part_pdp = [PointDipolePermanent(
-                    config=PointDipolePermanent.config.specify(dipm=0.7, size=2.,
-                    espresso_handle=sim_inst.sys)) for _ in range(10)] # mag_func = 0 for langevin and 1 for Froelich-Kennelly
-        sim_inst.store_objects(mag_part_pdp)
-        sim_inst.set_objects(mag_part_pdp)
+        def test_magnetize_Froelich_Kennelly(self):
+            mag_part_pds = [PointDipoleSuperpara(
+                        config=PointDipoleSuperpara.config.specify(dipm=1., mag_func=1, size=0.5,
+                        espresso_handle=sim_inst.sys)) for _ in range(10)]
+            sim_inst.store_objects(mag_part_pds)
+            sim_inst.set_objects(mag_part_pds)
+            mag_part_pdp = [PointDipolePermanent(
+                        config=PointDipolePermanent.config.specify(dipm=0.7, size=2.,
+                        espresso_handle=sim_inst.sys)) for _ in range(10)] # mag_func = 0 for langevin and 1 for Froelich-Kennelly
+            sim_inst.store_objects(mag_part_pdp)
+            sim_inst.set_objects(mag_part_pdp)
 
-        sim_inst.time_step = 0.001
-        sim_inst.sys.integrator.run(0, recalc_forces=True)
+            sim_inst.time_step = 0.001
+            sim_inst.sys.integrator.run(0, recalc_forces=True)
     

--- a/test/test_point_dipole.py
+++ b/test/test_point_dipole.py
@@ -1,0 +1,71 @@
+from pressomancy.simulation import PointDipolePermanent, PointDipoleSuperpara
+from create_system import sim_inst, BaseTestCase
+
+class PointDipoleTest(BaseTestCase):
+    H_ext = [0,0,3.]
+
+    def tearDown(self) -> None:
+        sim_inst.reinitialize_instance()
+        self.assertEqual(len(sim_inst.sys.part),0)
+
+    def test_set_object_generic(self):
+        mag_part = [PointDipolePermanent(config=PointDipolePermanent.config.specify(espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        sim_inst.set_objects(mag_part)
+        mag_part =  [PointDipoleSuperpara(config=PointDipoleSuperpara.config.specify(espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        sim_inst.set_objects(mag_part)
+        assert sim_inst.part_types["pds_real"] == 62 and sim_inst.part_types["pds_virt"] == 666
+
+    def test_set_object(self):
+        mag_part = [PointDipolePermanent(
+                    config=PointDipolePermanent.config.specify(dipm=1.2, size=2.,
+                    espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        sim_inst.set_objects(mag_part)
+        mag_part = [PointDipoleSuperpara(
+                    config=PointDipoleSuperpara.config.specify(dipm=1., Xi_0=0.1, size=0.5,
+                    espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        sim_inst.set_objects(mag_part)
+
+    def test_magnetize_PointDipoleSuperpara(self):
+        mag_part = [PointDipoleSuperpara(
+                    config=PointDipoleSuperpara.config.specify(dipm=1., size=0.5,
+                    espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part)
+        sim_inst.set_objects(mag_part)
+
+        sim_inst.time_step = 0.001
+        sim_inst.sys.integrator.run(0, recalc_forces=True)
+
+    def test_magnetize_mixture(self):
+        mag_part_pds = [PointDipoleSuperpara(
+                    config=PointDipoleSuperpara.config.specify(dipm=1., size=0.5,
+                    espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part_pds)
+        sim_inst.set_objects(mag_part_pds)
+        mag_part_pdp = [PointDipolePermanent(
+                    config=PointDipolePermanent.config.specify(dipm=0.7, size=2.,
+                    espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part_pdp)
+        sim_inst.set_objects(mag_part_pdp)
+
+        sim_inst.time_step = 0.001
+        sim_inst.sys.integrator.run(0, recalc_forces=True)
+
+    def test_magnetize_Froelich_Kennelly(self):
+        mag_part_pds = [PointDipoleSuperpara(
+                    config=PointDipoleSuperpara.config.specify(dipm=1., mag_func=1, size=0.5,
+                    espresso_handle=sim_inst.sys)) for _ in range(10)]
+        sim_inst.store_objects(mag_part_pds)
+        sim_inst.set_objects(mag_part_pds)
+        mag_part_pdp = [PointDipolePermanent(
+                    config=PointDipolePermanent.config.specify(dipm=0.7, size=2.,
+                    espresso_handle=sim_inst.sys)) for _ in range(10)] # mag_func = 0 for langevin and 1 for Froelich-Kennelly
+        sim_inst.store_objects(mag_part_pdp)
+        sim_inst.set_objects(mag_part_pdp)
+
+        sim_inst.time_step = 0.001
+        sim_inst.sys.integrator.run(0, recalc_forces=True)
+    

--- a/test/test_samples.py
+++ b/test/test_samples.py
@@ -17,6 +17,8 @@ class SampleScriptTest(BaseTestCase):
     def test_sample_scripts(self):
         def get_current_sim_instance(*args, **kwargs):
             """Helper function to return the latest `sim_inst`."""
+            if 'box_dim' in kwargs:
+                sim_inst.sys.box_l = kwargs['box_dim']
             return sim_inst        
         for _, module_name, _ in pkgutil.iter_modules(samples.__path__):
             Quadriplex.numInstances=0


### PR DESCRIPTION
-Added elastomer object class: fills a volume with an elastomer using magnetic particles connected by a bunch of springs, adhered to a substrate - meant for slab geometries with periodic x- and y-axis and open in the z-axis

-Added point dipole objects classses:
-- Permanet point dipole is a simple elastomer particle (may be redundat)
-- Superparamagnetic point dipole uses espresso's MAGNETIZE feature for magnetizable particles and is currently implemented with langevin and froelich-kennelly models, parameterized by saturation dipole moment and initial susceptibility.

Added tests for new objects, as well as sample scripts. Verified for espresso 4 and 5, even though the new objects have limitations in older versions and will raise MissingFeature erros is misused.

- Changed the feature sanity check in the simulations class to avoid raising "unkown featyre# error when an unkown feature is required, instead raising "missing feaure". This was to avoid changing the test_system to account for possible "unkown feature" errors. Maybe reverted at any point.